### PR TITLE
 TWINS-278 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,11 @@ out/
 *.iml
 *.ipr
 *.iws
-
+/core/build
+/core/.idea
+/logs
+/core/gradle
+gradle
 ##############################
 ## Eclipse
 ##############################
@@ -83,3 +87,5 @@ nb-configuration.xml
 ## OS X
 ##############################
 .DS_Store
+/gradlew.bat
+/gradlew

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,7 +1,8 @@
 plugins {
     // id 'war'
     id 'java'
-    id 'org.springframework.boot' version '3.1.0'
+    id 'io.spring.dependency-management' version '1.1.4'
+    id 'org.springframework.boot' version '3.3.3'
     id 'net.nemerosa.versioning' version '3.1.0'
     id 'com.bmuschko.docker-remote-api' version '9.3.4'
 }
@@ -41,7 +42,7 @@ task createDockerfile(type: Dockerfile) {
     dependsOn("bootJar")
     destFile.set(project.file("$dockerBuildDir/Dockerfile"))
 
-    from("bellsoft/liberica-openjdk-alpine:20-x86_64")
+    from("bellsoft/liberica-openjre-alpine:21.0.5")
     runCommand("mkdir -p $dockerWorkingDir")
     runCommand("mkdir $dockerWorkingDir/logs")
     workingDir(".$dockerWorkingDir")
@@ -80,34 +81,37 @@ task pushDockerImage(type: DockerBuildImage) {
 dependencies {
     compileOnly 'org.projectlombok:lombok:1.18.30'
     annotationProcessor 'org.projectlombok:lombok:1.18.30'
-    implementation("org.springframework:spring-web:6.0.11")
+    implementation("org.springframework:spring-web")
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.14.0'
     implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
-    implementation("org.springframework.boot:spring-boot-starter-web:3.2.0") {
+    implementation("org.springframework.boot:spring-boot-starter-web") {
         exclude module: "spring-boot-starter-tomcat"
         exclude module: "spring-boot-starter-jetty"
         exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'
         exclude module: "tomcat-embed-el"
         exclude group: "org.apache.tomcat"
     }
-    implementation('org.springframework.boot:spring-boot-starter-undertow:3.2.0')
-    implementation("org.springframework.amqp:spring-rabbit:3.1.0")
-    implementation("org.springframework.amqp:spring-amqp:3.1.0")
+    implementation('org.springframework.boot:spring-boot-starter-undertow')
+    implementation("org.springframework.amqp:spring-rabbit")
+    implementation("org.springframework.amqp:spring-amqp")
     implementation("org.apache.httpcomponents:httpclient:4.5.14")
     implementation("org.apache.httpcomponents.client5:httpclient5:5.2.1")
-    implementation("org.springframework.boot:spring-boot-starter-jdbc:3.2.0") {
+    implementation("org.springframework.boot:spring-boot-starter-jdbc") {
         exclude group: "com.zaxxer", module: "HikariCP"
     }
-    implementation("org.springframework.boot:spring-boot-starter-data-jpa:3.2.0")
-    runtimeOnly("org.postgresql:postgresql:42.7.1")
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    runtimeOnly("org.postgresql:postgresql:42.7.4")
     implementation('org.hibernate:hibernate-core:6.4.1.Final')
     implementation('io.hypersistence:hypersistence-utils-hibernate-62:3.6.1')
     implementation('org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0')
-    implementation('org.springframework.boot:spring-boot-starter-validation:3.2.0')
+    implementation('org.springframework.boot:spring-boot-starter-validation')
     implementation group: 'commons-validator', name: 'commons-validator', version: '1.8.0'
     implementation group: 'com.google.guava', name: 'guava', version: '32.1.3-jre'
-    implementation 'org.flywaydb:flyway-core:10.11.1'
-    implementation 'org.flywaydb:flyway-database-postgresql:10.11.1'
+    implementation 'org.flywaydb:flyway-core:11.0.0'
+    implementation 'org.flywaydb:flyway-database-postgresql:11.0.0'
+
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 }
 
 configurations {

--- a/core/src/main/resources/application.properties
+++ b/core/src/main/resources/application.properties
@@ -8,6 +8,18 @@ logging.level.io.springfox=DEBUG
 spring.main.allow-circular-references=true
 spring.main.lazy-initialization=true
 
+management.tracing.sampling.probability=1.0
+management.endpoints.web.exposure.include=health, prometheus
+management.endpoints.web.base-path=/actuator
+management.endpoints.web.path-mapping.prometheus=prometheus
+management.endpoint.health.show-details=never
+management.endpoint.health.enabled=false
+management.prometheus.metrics.export.enabled=false
+management.health.rabbit.enabled=false
+management.metrics.distribution.percentiles-histogram.http.server.requests=false
+management.metrics.distribution.percentiles-histogram.spring.data.repository=false
+
+spring.datasource.hikari.pool-name=twins-pool
 spring.datasource.url=jdbc:postgresql://localhost:5432/twins
 spring.datasource.username=username
 spring.datasource.password=password


### PR DESCRIPTION
Update Spring Boot, dependencies,project configurations and add prometheus metrics

Upgraded Spring Boot to 3.3.3 and various dependencies for compatibility and functionality improvements. Adjusted the `.gitignore` file to include additional ignores and modified Docker configuration to use the latest Liberica JRE. Added Actuator and Prometheus metrics configurations, along with updated Flyway and Hikari properties.

1. Upgrading Spring Boot to version **3.3.3** allows updating dependencies and utilizing components with fixed vulnerabilities.

2. Using **dependency-management** simplifies the inclusion of up-to-date dependencies for Spring Boot without specifying their exact versions, which helps avoid dependency conflicts.

3. Using the base image `bellsoft/liberica-openjre-alpine:21.0.5` will reduce the size of the final image, minimize the attack surface, and optimize the container's memory consumption.

4. Added metric collection settings. These are disabled by default and can be enabled as needed
management.tracing.sampling.probability=1.0 
management.endpoints.web.exposure.include=health, prometheus
management.endpoints.web.base-path=/actuator
management.endpoints.web.path-mapping.prometheus=prometheus
management.endpoint.health.show-details=never
management.endpoint.health.enabled=false
management.prometheus.metrics.export.enabled=false
management.health.rabbit.enabled=false
management.metrics.distribution.percentiles-histogram.http.server.requests=false
management.metrics.distribution.percentiles-histogram.spring.data.repository=false

5. Added the database connection pool name configuration:
`spring.datasource.hikari.pool-name=twins-pool`

6. 1. Adding directory and file exclusions to `.gitignore` to prevent accidental additions to the repository.