### PR TITLE
Update caching to use Caffeine and log filters for Prometheus

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -91,6 +91,8 @@ dependencies {
         exclude module: "tomcat-embed-el"
         exclude group: "org.apache.tomcat"
     }
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation('com.github.ben-manes.caffeine:caffeine')
     implementation('org.springframework.boot:spring-boot-starter-undertow')
     implementation("org.springframework.amqp:spring-rabbit")
     implementation("org.springframework.amqp:spring-amqp")

--- a/core/src/main/java/org/twins/core/config/ApplicationConfig.java
+++ b/core/src/main/java/org/twins/core/config/ApplicationConfig.java
@@ -10,9 +10,11 @@ package org.twins.core.config;
 
 
 import com.github.benmanes.caffeine.cache.Caffeine;
+import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;
 import org.cambium.service.EntitySmartService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.autoconfigure.metrics.MeterRegistryCustomizer;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 import org.springframework.cache.CacheManager;
@@ -78,6 +80,20 @@ public class ApplicationConfig {
     public LoggingFilter loggingFilter() {
         return new LoggingFilter();
     }
+
+    /**
+     * Configures a MeterRegistry with common tags applied to all metrics.
+     * This method customizes the MeterRegistry by adding a common tag
+     * "application" with the value "TWINS".
+     * These common tags are applied
+     * to every metric created in the application, allowing for consistent
+     * tagging and easier identification of metrics.
+     *
+     * @return a customizer for MeterRegistry that applies common tags.
+     */
+    @Bean
+    public MeterRegistryCustomizer<MeterRegistry> meterRegistry() {
+        return (registry) -> registry.config().commonTags("application", "TWINS");}
 
      /**
       * Configures and provides a CacheManager bean using Caffeine as the caching provider.


### PR DESCRIPTION
1. Excluding Prometheus metric requests from logging.

2. Suggest using **Caffeine** as a caching solution, which is expected to improve cache performance. The **CaffeineCacheManager** offers significant advantages over **ConcurrentMapCacheManager**, such as superior performance, automatic eviction of expired entries, more efficient memory management, and built-in support for various expiration and eviction policies. This makes it an excellent choice for high-performance caching.
3. Introduced a MeterRegistryCustomizer bean to apply common tags to all metrics, including an "application" tag with the value "TWINS". This ensures consistent tagging across the application's metrics, simplifying monitoring and analysis.