### PR TITLE
Twins 291 core update jdk version switch on z generational garbage collector

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ subprojects {
         mavenCentral()
     }
 
-    sourceCompatibility = "1.17"
+    sourceCompatibility = '21'
 
     tasks.withType(JavaCompile) {
         options.encoding = 'UTF-8'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -43,8 +43,7 @@ task createDockerfile(type: Dockerfile) {
     destFile.set(project.file("$dockerBuildDir/Dockerfile"))
 
     from("bellsoft/liberica-openjre-alpine:21.0.5")
-    runCommand("mkdir -p $dockerWorkingDir")
-    runCommand("mkdir $dockerWorkingDir/logs")
+    runCommand("mkdir -p $dockerWorkingDir/logs")
     workingDir(".$dockerWorkingDir")
     addFile("$jarName", "$dockerWorkingDir/twins.jar")
     entryPoint("java")

--- a/core/docker-compose.yml
+++ b/core/docker-compose.yml
@@ -6,9 +6,19 @@ services:
   twins:
     image: dockerhub.esas.by/twins:0.1.0-SNAPSHOT
     container_name: twins-core
+    hostname: twins-core
     environment:
-      - JAVA_OPTS="-Djdk.internal.httpclient.debug=true"
-      - JAVA_TOOL_OPTIONS="-Xrunjdwp:transport=dt_socket,address=*:5006,server=y,suspend=n"
+      JAVA_TOOL_OPTIONS: "
+      -XX:+UseZGC 
+      -XX:+ZGenerational
+      -Xrunjdwp:transport=dt_socket
+      -address=*:5006 
+      -server=y
+      -suspend=n
+       "
+      JAVA_OPTS: "
+      -Djdk.internal.httpclient.debug=true
+      "
     volumes:
       - ./logs:/opt/twins/logs
     ports:

--- a/core/src/main/java/org/twins/core/config/RestTemplateConfig.java
+++ b/core/src/main/java/org/twins/core/config/RestTemplateConfig.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 
 @Slf4j
@@ -29,7 +30,7 @@ class RestTemplateConfig {
             return response;
         }
 
-        private void traceRequest(UUID id, HttpRequest request, byte[] body) throws IOException {
+        private void traceRequest(UUID id, HttpRequest request, byte[] body) {
             StringBuilder sb = new StringBuilder();
             sb.append("===========================request begin================================================\n").
                     append("=ID         : {}\n").
@@ -38,12 +39,12 @@ class RestTemplateConfig {
                     append("=Headers     : {}\n").
                     append("=Request body: {}\n").
                     append("==========================request end================================================");
-            log.info(sb.toString(), id.toString(), request.getURI(), request.getMethod(), request.getHeaders(), new String(body, "UTF-8"));
+            log.info(sb.toString(), id.toString(), request.getURI(), request.getMethod(), request.getHeaders(), new String(body, StandardCharsets.UTF_8));
         }
 
         private void traceResponse(UUID id, ClientHttpResponse response, HttpRequest request) throws IOException {
             StringBuilder inputStringBuilder = new StringBuilder();
-            BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(response.getBody(), "UTF-8"));
+            BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(response.getBody(), StandardCharsets.UTF_8));
             String line = bufferedReader.readLine();
             while (line != null) {
                 inputStringBuilder.append(line);
@@ -61,10 +62,8 @@ class RestTemplateConfig {
                     append("=Headers      : {}\n").
                     append("=Response body: {}\n").
                     append("=======================response end=================================================");
-            log.info(sb.toString(), id.toString(), request.getURI(), request.getMethod(), response.getStatusCode(), response.getStatusText(), response.getHeaders(), inputStringBuilder.toString());
+            log.info(sb.toString(), id.toString(), request.getURI(), request.getMethod(), response.getStatusCode(), response.getStatusText(), response.getHeaders(), inputStringBuilder);
 
         }
     }
-
-
 }

--- a/core/src/main/java/org/twins/core/config/WebConfig.java
+++ b/core/src/main/java/org/twins/core/config/WebConfig.java
@@ -1,6 +1,6 @@
 package org.twins.core.config;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -11,10 +11,10 @@ import org.twins.core.service.MapperModesResolveService;
 import java.util.List;
 
 @Configuration
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
 
-    @Autowired
-    private MapperModesResolveService mapperModesResolveService;
+    private final MapperModesResolveService mapperModesResolveService;
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {

--- a/core/src/main/java/org/twins/core/config/openapi/OpenApiConfig.java
+++ b/core/src/main/java/org/twins/core/config/openapi/OpenApiConfig.java
@@ -3,17 +3,17 @@ package org.twins.core.config.openapi;
 import io.swagger.v3.oas.models.ExternalDocumentation;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import lombok.RequiredArgsConstructor;
 import org.springdoc.core.models.GroupedOpenApi;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.twins.core.service.MapperModesResolveService;
 
 @Configuration
+@RequiredArgsConstructor
 public class OpenApiConfig {
 
-    @Autowired
-    private MapperModesResolveService mapperParameterService;
+    private final MapperModesResolveService mapperParameterService;
 
     @Bean
     public OpenAPI openApi() {


### PR DESCRIPTION
1. Changed the sourceCompatibility in build.gradle from 1.17 to 21. This ensures compatibility with the latest Java features and standards.
2. Consolidated redundant mkdir commands into a single command using the `-p` flag for creating the logs directory. This reduces unnecessary steps and ensures cleaner and more maintainable code.
3. Added a hostname for the twins-core container. Simplified and structured JAVA options, enabling ZGC and generational ZGC alongside debugging configurations. These changes improve readability and optimize JVM behavior
4. Replaced string-based charset instances with `StandardCharsets.UTF_8` for improved readability and ensured immutability. Refactored `@Autowired` injections to `@RequiredArgsConstructor` for better constructor-based dependency injection