### PR TITLE
TWINS-281: Fix TwinSearchService bugs and improve validation logic

### DIFF
--- a/core/src/main/java/org/cambium/common/util/CollectionUtils.java
+++ b/core/src/main/java/org/cambium/common/util/CollectionUtils.java
@@ -81,4 +81,8 @@ public class CollectionUtils extends org.apache.commons.collections.CollectionUt
         return new HashSet<>(collection);
     }
 
+    public static boolean isEmpty(Map coll) {
+        return coll == null ||
+                coll.isEmpty();
+    }
 }

--- a/core/src/main/java/org/twins/core/dao/specifications/AbstractTwinEntityBasicSearchSpecification.java
+++ b/core/src/main/java/org/twins/core/dao/specifications/AbstractTwinEntityBasicSearchSpecification.java
@@ -9,6 +9,7 @@ import org.cambium.common.util.LTreeUtils;
 import org.springframework.data.jpa.domain.Specification;
 import org.twins.core.dao.twin.TwinEntity;
 import org.twins.core.dao.twin.TwinLinkEntity;
+import org.twins.core.dao.twin.TwinMarkerEntity;
 import org.twins.core.dao.twin.TwinTouchEntity;
 import org.twins.core.dao.twinclass.TwinClassEntity;
 import org.twins.core.domain.search.TwinFieldSearch;
@@ -33,7 +34,7 @@ public abstract class AbstractTwinEntityBasicSearchSpecification<T> extends Comm
         String[] hierarchyTreeFieldPath = concatArray(twinsEntityFieldPath, TwinEntity.Fields.hierarchyTree);
         String[] twinClassIdFieldPath = concatArray(twinsEntityFieldPath, TwinEntity.Fields.twinClassId);
         String[] tagsFieldPath = concatArray(twinsEntityFieldPath, TwinEntity.Fields.tags);
-        String[] markersFieldPath = concatArray(twinsEntityFieldPath, TwinEntity.Fields.markers);
+        String[] markersFieldPath = concatArray(twinsEntityFieldPath, TwinEntity.Fields.markers, TwinMarkerEntity.Fields.markerDataListOptionId);
         String[] touchFieldPath = concatArray(twinsEntityFieldPath, TwinEntity.Fields.touches);
 
         var commonSpecifications = new Specification[]{

--- a/core/src/main/java/org/twins/core/dao/specifications/AbstractTwinEntityBasicSearchSpecification.java
+++ b/core/src/main/java/org/twins/core/dao/specifications/AbstractTwinEntityBasicSearchSpecification.java
@@ -7,10 +7,7 @@ import org.cambium.common.exception.ServiceException;
 import org.cambium.common.util.CollectionUtils;
 import org.cambium.common.util.LTreeUtils;
 import org.springframework.data.jpa.domain.Specification;
-import org.twins.core.dao.twin.TwinEntity;
-import org.twins.core.dao.twin.TwinLinkEntity;
-import org.twins.core.dao.twin.TwinMarkerEntity;
-import org.twins.core.dao.twin.TwinTouchEntity;
+import org.twins.core.dao.twin.*;
 import org.twins.core.dao.twinclass.TwinClassEntity;
 import org.twins.core.domain.search.TwinFieldSearch;
 import org.twins.core.domain.search.TwinSearch;
@@ -33,7 +30,7 @@ public abstract class AbstractTwinEntityBasicSearchSpecification<T> extends Comm
         String[] headTwinIdFieldPath = concatArray(twinsEntityFieldPath, TwinEntity.Fields.headTwinId);
         String[] hierarchyTreeFieldPath = concatArray(twinsEntityFieldPath, TwinEntity.Fields.hierarchyTree);
         String[] twinClassIdFieldPath = concatArray(twinsEntityFieldPath, TwinEntity.Fields.twinClassId);
-        String[] tagsFieldPath = concatArray(twinsEntityFieldPath, TwinEntity.Fields.tags);
+        String[] tagsFieldPath = concatArray(twinsEntityFieldPath, TwinEntity.Fields.tags, TwinTagEntity.Fields.tagDataListOptionId);
         String[] markersFieldPath = concatArray(twinsEntityFieldPath, TwinEntity.Fields.markers, TwinMarkerEntity.Fields.markerDataListOptionId);
         String[] touchFieldPath = concatArray(twinsEntityFieldPath, TwinEntity.Fields.touches);
 

--- a/core/src/main/java/org/twins/core/dao/specifications/AbstractTwinEntityBasicSearchSpecification.java
+++ b/core/src/main/java/org/twins/core/dao/specifications/AbstractTwinEntityBasicSearchSpecification.java
@@ -152,13 +152,18 @@ public abstract class AbstractTwinEntityBasicSearchSpecification<T> extends Comm
             }
 
             TriFunction<CriteriaBuilder, List<Predicate>, List<Predicate>, Predicate> getIncludeExcludePredicateFunction = (builder, any, all) -> {
-                boolean anyExist = !predicatesAny.isEmpty();
-                boolean allExist = !predicatesAll.isEmpty();
+                boolean anyExist = !any.isEmpty();
+                boolean allExist = !all.isEmpty();
                 boolean anyAndAllExist = anyExist && allExist;
-                return anyAndAllExist ? builder.and(builder.or(any.toArray(new Predicate[0])), builder.and(all.toArray(new Predicate[0]))) :
-                        anyExist ? builder.or(any.toArray(new Predicate[0])) :
-                                allExist ? builder.and(any.toArray(new Predicate[0])) :
-                                        builder.conjunction();
+                if (anyAndAllExist) {
+                    return builder.and(builder.or(any.toArray(new Predicate[0])), builder.and(all.toArray(new Predicate[0])));
+                } else if (anyExist) {
+                    return builder.or(any.toArray(new Predicate[0]));
+                } else if (allExist) {
+                    return builder.and(any.toArray(new Predicate[0]));
+                } else {
+                    return builder.conjunction();
+                }
             };
             Predicate include = getIncludeExcludePredicateFunction.apply(cb, predicatesAny, predicatesAll);
             Predicate exclude = getIncludeExcludePredicateFunction.apply(cb, excludePredicatesAny, excludePredicatesAll);

--- a/core/src/main/java/org/twins/core/dao/specifications/CommonSpecification.java
+++ b/core/src/main/java/org/twins/core/dao/specifications/CommonSpecification.java
@@ -183,8 +183,8 @@ public class CommonSpecification<T> extends AbstractSpecification<T> {
     public static <T> Specification<T> checkUuidIn(final Collection<UUID> uuids, boolean not,
                                                    boolean includeNullValues, final String... uuidFieldPath) {
         return (root, query, cb) -> {
-            Path<UUID> fildPath = getFildPath(root, includeNullValues ? JoinType.LEFT : JoinType.INNER, uuidFieldPath);
             if (CollectionUtils.isEmpty(uuids)) return cb.conjunction();
+            Path<UUID> fildPath = getFildPath(root, includeNullValues ? JoinType.LEFT : JoinType.INNER, uuidFieldPath);
             Predicate predicate = not ? fildPath.in(uuids).not() : fildPath.in(uuids);
             return includeNullValues ? cb.or(predicate, fildPath.isNull()) : cb.and(predicate, fildPath.isNotNull());
         };

--- a/core/src/main/java/org/twins/core/domain/search/TwinSearch.java
+++ b/core/src/main/java/org/twins/core/domain/search/TwinSearch.java
@@ -48,6 +48,40 @@ public class TwinSearch {
     Set<TwinTouchEntity.Touch> touchExcludeList;
     List<TwinFieldSearch> fields;
 
+    public boolean isEmpty() {
+        return CollectionUtils.isEmpty(twinIdList) &&
+                CollectionUtils.isEmpty(twinNameLikeList) &&
+                CollectionUtils.isEmpty(twinNameNotLikeList) &&
+                CollectionUtils.isEmpty(twinDescriptionLikeList) &&
+                CollectionUtils.isEmpty(twinDescriptionNotLikeList) &&
+                CollectionUtils.isEmpty(twinIdExcludeList) &&
+                CollectionUtils.isEmpty(twinClassIdList) &&
+                CollectionUtils.isEmpty(twinClassIdExcludeList) &&
+                CollectionUtils.isEmpty(headTwinClassIdList) &&
+                CollectionUtils.isEmpty(extendsTwinClassIdList) &&
+                CollectionUtils.isEmpty(headerTwinIdList) &&
+                CollectionUtils.isEmpty(statusIdList) &&
+                CollectionUtils.isEmpty(assigneeUserIdList) &&
+                CollectionUtils.isEmpty(assigneeUserIdExcludeList) &&
+                CollectionUtils.isEmpty(createdByUserIdList) &&
+                CollectionUtils.isEmpty(createdByUserIdExcludeList) &&
+                CollectionUtils.isEmpty(ownerUserIdList) &&
+                CollectionUtils.isEmpty(ownerBusinessAccountIdList) &&
+                CollectionUtils.isEmpty(linksAnyOfList) &&
+                CollectionUtils.isEmpty(linksNoAnyOfList) &&
+                CollectionUtils.isEmpty(linksAllOfList) &&
+                CollectionUtils.isEmpty(linksNoAllOfList) &&
+                CollectionUtils.isEmpty(hierarchyTreeContainsIdList) &&
+                CollectionUtils.isEmpty(statusIdExcludeList) &&
+                CollectionUtils.isEmpty(tagDataListOptionIdList) &&
+                CollectionUtils.isEmpty(tagDataListOptionIdExcludeList) &&
+                CollectionUtils.isEmpty(markerDataListOptionIdList) &&
+                CollectionUtils.isEmpty(markerDataListOptionIdExcludeList) &&
+                CollectionUtils.isEmpty(touchList) &&
+                CollectionUtils.isEmpty(touchExcludeList) &&
+                CollectionUtils.isEmpty(fields);
+    }
+
     public TwinSearch addTwinId(UUID twinId, boolean exclude) {
         if (exclude)
             twinIdExcludeList = CollectionUtils.safeAdd(twinIdExcludeList, twinId);
@@ -142,7 +176,7 @@ public class TwinSearch {
     public TwinSearch addLinkDstTwinsId(UUID linkId, Collection<UUID> dstTwinIdList, boolean exclude, boolean or) {
         Map<UUID, Set<UUID>> map = null;
         if (exclude) {
-            if(or) {
+            if (or) {
                 if (linksNoAnyOfList == null) linksNoAnyOfList = new HashMap<>();
                 map = linksNoAnyOfList;
             } else {
@@ -150,7 +184,7 @@ public class TwinSearch {
                 map = linksNoAllOfList;
             }
         } else {
-            if(or) {
+            if (or) {
                 if (linksAnyOfList == null) linksAnyOfList = new HashMap<>();
                 map = linksAnyOfList;
             } else {

--- a/core/src/main/java/org/twins/core/service/twin/TwinSearchService.java
+++ b/core/src/main/java/org/twins/core/service/twin/TwinSearchService.java
@@ -88,7 +88,8 @@ public class TwinSearchService {
 
 
         //HEAD TWIN CHECK
-        if (null != basicSearch.getHeadSearch()) specification = specification.and(
+        if (null != basicSearch.getHeadSearch() && !basicSearch.getHeadSearch().isEmpty())
+            specification = specification.and(
                 checkHeadTwin(
                         createTwinEntityBasicSearchSpecification(basicSearch.getHeadSearch(),userId),
                         basicSearch.getHeadSearch()

--- a/core/src/main/java/org/twins/core/service/twin/TwinSearchService.java
+++ b/core/src/main/java/org/twins/core/service/twin/TwinSearchService.java
@@ -96,7 +96,8 @@ public class TwinSearchService {
                 ));
 
         //CHILDREN TWINS CHECK
-        if (null != basicSearch.getChildrenSearch()) specification = specification.and(
+        if (null != basicSearch.getChildrenSearch() && !basicSearch.getChildrenSearch().isEmpty())
+            specification = specification.and(
                 checkChildrenTwins(
                         createTwinEntityBasicSearchSpecification(basicSearch.getChildrenSearch(),userId),
                         basicSearch.getChildrenSearch()


### PR DESCRIPTION
### Description

This pull request addresses the following changes and fixes:

- Fixed issues with `any/all` links in twin search and refactored conditional logic in the predicate builder.
- Resolved null and empty checks for `childrenSearch` in `TwinSearchService`.
- Added validation for empty `TwinSearch` and map collection checks.
- Fixed bugs involving unnecessary left joins during UUID searches.
- Corrected issues with `getTagDataListOptionIdList` and `getMarkerDataListOptionIdList` searches.

### Checklist

- [ ] Unit tests added/updated as required
- [ ] Documentation updated as needed
- [ ] All relevant tests executed and