### PR TITLE
TWINS-432:

### DIFF
--- a/core/src/main/java/org/twins/core/config/EncryptionConfig.java
+++ b/core/src/main/java/org/twins/core/config/EncryptionConfig.java
@@ -17,7 +17,7 @@ public class EncryptionConfig {
     @Value("${twin.field.password.key}")
     private String secretKey;
 
-    @Value("${twin.field.password.algorithm}")
+    @Value("${twin.field.password.algorithm:PBEWithMD5AndDES}")
     private String cryptoAlgorithm = "PBEWithMD5AndDES";
 
     @Bean
@@ -43,7 +43,7 @@ public class EncryptionConfig {
         EncryptionConfig.featurerParamCryptPassword = key;
     }
 
-    @Value("${featurer.param.encrypt.algorithm}")
+    @Value("${featurer.param.encrypt.algorithm:PBEWithMD5AndDES}")
     public void setAlgorithm(String algorithm) {
         if (EncryptionConfig.featurerParamCryptAlgorithm != null) return;
         EncryptionConfig.featurerParamCryptAlgorithm = algorithm;

--- a/core/src/main/java/org/twins/core/controller/rest/priv/attachment/AttachmentCUDValidateController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/attachment/AttachmentCUDValidateController.java
@@ -51,7 +51,7 @@ public class AttachmentCUDValidateController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/attachment/validate_cud/v1")
     public ResponseEntity<?> attachmentValidateV1(
-            @MapperContextBinding(roots = AttachmentCUDValidateRestDTOMapper.class, response = AttachmentCUDValidateRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = AttachmentCUDValidateRestDTOMapper.class, response = AttachmentCUDValidateRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @RequestBody AttachmentCUDValidateRqDTOv1 request) {
         AttachmentCUDValidateRsDTOv1 rs = new AttachmentCUDValidateRsDTOv1();
         try {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/attachment/AttachmentDomainBusinessAccountQuotasController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/attachment/AttachmentDomainBusinessAccountQuotasController.java
@@ -47,7 +47,7 @@ public class AttachmentDomainBusinessAccountQuotasController extends ApiControll
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/private/attachment/quotas/domain_business_account/v1")
     public ResponseEntity<?> attachmentDomainBusinessAccountQuotasV1(
-            @MapperContextBinding(roots = AttachmentQuotasRestDTOMapper.class, response = AttachmentQuotasRsDTOv1.class) MapperContext mapperContext) {
+            @MapperContextBinding(roots = AttachmentQuotasRestDTOMapper.class, response = AttachmentQuotasRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext) {
         AttachmentQuotasRsDTOv1 rs = new AttachmentQuotasRsDTOv1();
         try {
             rs.setQuotas(

--- a/core/src/main/java/org/twins/core/controller/rest/priv/attachment/AttachmentDomainQuotasController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/attachment/AttachmentDomainQuotasController.java
@@ -46,7 +46,7 @@ public class AttachmentDomainQuotasController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/private/attachment/quotas/domain/v1")
     public ResponseEntity<?> attachmentDomainQuotasV1(
-            @MapperContextBinding(roots = AttachmentQuotasRestDTOMapper.class, response = AttachmentQuotasRsDTOv1.class) MapperContext mapperContext) {
+            @MapperContextBinding(roots = AttachmentQuotasRestDTOMapper.class, response = AttachmentQuotasRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext) {
         AttachmentQuotasRsDTOv1 rs = new AttachmentQuotasRsDTOv1();
         try {
             rs.setQuotas(

--- a/core/src/main/java/org/twins/core/controller/rest/priv/attachment/AttachmentSearchController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/attachment/AttachmentSearchController.java
@@ -54,7 +54,7 @@ public class AttachmentSearchController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/attachment/search/v1")
     public ResponseEntity<?> attachmentSearchV1(
-            @MapperContextBinding(roots = AttachmentRestDTOMapper.class, response = AttachmentSearchRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = AttachmentRestDTOMapper.class, response = AttachmentSearchRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @SimplePaginationParams SimplePagination pagination,
             @RequestBody AttachmentSearchRqDTOv1 request) {
         AttachmentSearchRsDTOv1 rs = new AttachmentSearchRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/attachment/AttachmentViewController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/attachment/AttachmentViewController.java
@@ -50,7 +50,7 @@ public class AttachmentViewController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/private/attachment/{attachmentId}/v1")
     public ResponseEntity<?> attachmentViewV1(
-            @MapperContextBinding(roots = AttachmentRestDTOMapper.class, response = AttachmentViewRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = AttachmentRestDTOMapper.class, response = AttachmentViewRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.ATTACHMENT_ID) @PathVariable UUID attachmentId) {
         AttachmentViewRsDTOv1 rs = new AttachmentViewRsDTOv1();
         try {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/card/TwinClassCardListController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/card/TwinClassCardListController.java
@@ -50,7 +50,7 @@ public class TwinClassCardListController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/private/twin_class/{twinClassId}/card/list/v1")
     public ResponseEntity<?> twinClassCardListV1(
-            @MapperContextBinding(roots = CardRestDTOMapper.class, response = CardListRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = CardRestDTOMapper.class, response = CardListRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.TWIN_CLASS_ID) @PathVariable UUID twinClassId) {
         CardListRsDTOv1 rs = new CardListRsDTOv1();
         try {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/comment/CommentListController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/comment/CommentListController.java
@@ -55,7 +55,7 @@ public class CommentListController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/private/comment/twin/{twinId}/v1")
     public ResponseEntity<?> twinCommentListV1(
-            @MapperContextBinding(roots = CommentRestDTOMapper.class, response = CommentListRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = CommentRestDTOMapper.class, response = CommentListRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @SimplePaginationParams(sortAsc = false, sortField = TwinCommentEntity.Fields.createdAt) SimplePagination pagination,
             @Parameter(example = DTOExamples.TWIN_ID) @PathVariable UUID twinId) {
         CommentListRsDTOv1 rs = new CommentListRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/comment/CommentSearchController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/comment/CommentSearchController.java
@@ -53,7 +53,7 @@ public class CommentSearchController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/comment/search/v1")
     public ResponseEntity<?> commentSearchV1(
-            @MapperContextBinding(roots = CommentRestDTOMapper.class, response = CommentSearchRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = CommentRestDTOMapper.class, response = CommentSearchRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @SimplePaginationParams SimplePagination pagination,
             @RequestBody CommentSearchRqDTOv1 request) {
         CommentSearchRsDTOv1 rs = new CommentSearchRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/comment/CommentUpdateController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/comment/CommentUpdateController.java
@@ -50,7 +50,7 @@ public class CommentUpdateController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PutMapping(value = "/private/comment/{commentId}/v1")
     public ResponseEntity<?> twinCommentUpdateV1(
-            @MapperContextBinding(roots = CommentRestDTOMapper.class, response = CommentRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = CommentRestDTOMapper.class, response = CommentRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.TWIN_COMMENT_ID) @PathVariable UUID commentId,
             @RequestBody CommentUpdateRqDTOv1 request) {
         CommentRsDTOv1 rs = new CommentRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/comment/CommentViewController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/comment/CommentViewController.java
@@ -48,7 +48,7 @@ public class CommentViewController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/private/comment/{commentId}/v1")
     public ResponseEntity<?> twinCommentV1(
-            @MapperContextBinding(roots = CommentRestDTOMapper.class, response = CommentRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = CommentRestDTOMapper.class, response = CommentRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.TWIN_COMMENT_ID) @PathVariable UUID commentId) {
         CommentRsDTOv1 rs = new CommentRsDTOv1();
         try {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/datalist/DataListController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/datalist/DataListController.java
@@ -51,7 +51,7 @@ public class DataListController extends ApiController {
     @GetMapping(value = "/private/data_list/{dataListId}/v1")
     @Loggable(rsBodyThreshold = 1000)
     public ResponseEntity<?> dataListViewV1(
-            @MapperContextBinding(roots = DataListRestDTOMapperV2.class, response = DataListRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = DataListRestDTOMapperV2.class, response = DataListRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.DATA_LIST_ID) @PathVariable UUID dataListId) {
         DataListRsDTOv1 rs = new DataListRsDTOv1();
         try {
@@ -74,7 +74,7 @@ public class DataListController extends ApiController {
     @GetMapping(value = "/private/data_list_by_key/{dataListKey}/v1")
     @Loggable(rsBodyThreshold = 1000)
     public ResponseEntity<?> dataListByKeyViewV1(
-            @MapperContextBinding(roots = DataListRestDTOMapperV2.class, response = DataListRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = DataListRestDTOMapperV2.class, response = DataListRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.DATA_LIST_KEY) @PathVariable String dataListKey) {
         DataListRsDTOv1 rs = new DataListRsDTOv1();
         try {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/datalist/DataListCreateController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/datalist/DataListCreateController.java
@@ -51,7 +51,7 @@ public class DataListCreateController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/data_list/v1")
     public ResponseEntity<?> dataListCreateV1(
-            @MapperContextBinding(roots = DataListRestDTOMapperV2.class, response = DataListRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = DataListRestDTOMapperV2.class, response = DataListRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @RequestBody DataListCreateRqDTOv1 request) {
         DataListRsDTOv1 rs = new DataListRsDTOv1();
         try {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/datalist/DataListOptionController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/datalist/DataListOptionController.java
@@ -49,7 +49,7 @@ public class DataListOptionController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/private/data_list_option/{dataListOptionId}/v1")
     public ResponseEntity<?> dataListOptionV1(
-            @MapperContextBinding(roots = DataListOptionRestDTOMapperV3.class, response = DataListOptionRsDTOv3.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = DataListOptionRestDTOMapperV3.class, response = DataListOptionRsDTOv3.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.DATA_LIST_OPTION_ID) @PathVariable UUID dataListOptionId) {
         DataListOptionRsDTOv3 rs = new DataListOptionRsDTOv3();
         try {
@@ -73,7 +73,7 @@ public class DataListOptionController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @RequestMapping(value = "/private/data_list_option/map/v1", method = RequestMethod.POST)
     public ResponseEntity<?> dataListsOptionsMapV1(
-            @MapperContextBinding(roots = DataListOptionRestDTOMapper.class, response = DataListOptionMapRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = DataListOptionRestDTOMapper.class, response = DataListOptionMapRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @RequestBody DataListOptionMapRqDTOv1 request) {
         DataListOptionMapRsDTOv1 rs = new DataListOptionMapRsDTOv1();
         try {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/datalist/DataListOptionCreateController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/datalist/DataListOptionCreateController.java
@@ -58,7 +58,7 @@ public class DataListOptionCreateController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/data_list_option/v1")
     public ResponseEntity<?> dataListOptionCreateV1(
-            @MapperContextBinding(roots = DataListOptionRestDTOMapperV3.class, response = DataListOptionRsDTOv3.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = DataListOptionRestDTOMapperV3.class, response = DataListOptionRsDTOv3.class) @Schema(hidden = true) MapperContext mapperContext,
             @RequestBody DataListOptionCreateRqDTOv1 request) {
         DataListOptionRsDTOv3 rs = new DataListOptionRsDTOv3();
         try {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/datalist/DataListOptionSearchController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/datalist/DataListOptionSearchController.java
@@ -55,7 +55,7 @@ public class DataListOptionSearchController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/data_list_option/search/v1")
     public ResponseEntity<?> dataListOptionSearchListV1(
-            @MapperContextBinding(roots = DataListOptionRestDTOMapperV3.class, response = DataListOptionSearchRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = DataListOptionRestDTOMapperV3.class, response = DataListOptionSearchRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @RequestBody DataListOptionSearchRqDTOv1 request,
             @SimplePaginationParams(sortField = DataListOptionEntity.Fields.option) SimplePagination pagination) {
         DataListOptionSearchRsDTOv1 rs = new DataListOptionSearchRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/datalist/DataListOptionUpdateController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/datalist/DataListOptionUpdateController.java
@@ -58,7 +58,7 @@ public class DataListOptionUpdateController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PutMapping(value = "/private/data_list_option/{dataListOptionId}/v1")
     public ResponseEntity<?> dataListOptionUpdateV1(
-            @MapperContextBinding(roots = DataListOptionRestDTOMapperV3.class, response = DataListOptionRsDTOv3.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = DataListOptionRestDTOMapperV3.class, response = DataListOptionRsDTOv3.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.DATA_LIST_OPTION_ID) @PathVariable UUID dataListOptionId,
             @RequestBody DataListOptionUpdateRqDTOv1 request) {
         DataListOptionRsDTOv3 rs = new DataListOptionRsDTOv3();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/datalist/DataListSearchController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/datalist/DataListSearchController.java
@@ -50,7 +50,7 @@ public class DataListSearchController extends ApiController {
     @PostMapping(value = "/private/data_list/search/v1")
     @Loggable(rsBodyThreshold = 1000)
     public ResponseEntity<?> dataListSearchV1(
-            @MapperContextBinding(roots = DataListRestDTOMapperV2.class, response = DataListSearchRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = DataListRestDTOMapperV2.class, response = DataListSearchRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @SimplePaginationParams SimplePagination pagination,
             @RequestBody DataListSearchRqDTOv1 request) {
         DataListSearchRsDTOv1 rs = new DataListSearchRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/datalist/DataListUpdateController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/datalist/DataListUpdateController.java
@@ -52,7 +52,7 @@ public class DataListUpdateController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PutMapping(value = "/private/data_list/{dataListId}/v1")
     public ResponseEntity<?> dataListUpdateV1(
-            @MapperContextBinding(roots = DataListRestDTOMapperV2.class, response = DataListRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = DataListRestDTOMapperV2.class, response = DataListRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.DATA_LIST_ID) @PathVariable UUID dataListId,
             @RequestBody DataListUpdateRqDTOv1 request) {
         DataListRsDTOv1 rs = new DataListRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/domain/DomainBusinessAccountListController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/domain/DomainBusinessAccountListController.java
@@ -58,7 +58,7 @@ public class DomainBusinessAccountListController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/domain/business_account/search/v1")
     public ResponseEntity<?> domainBusinessAccountSearchV1(
-            @MapperContextBinding(roots = DomainBusinessAccountDTOMapper.class, response = DomainBusinessAccountSearchRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = DomainBusinessAccountDTOMapper.class, response = DomainBusinessAccountSearchRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @SimplePaginationParams SimplePagination pagination,
             @RequestBody DomainBusinessAccountSearchRqDTOv1 request) {
         DomainBusinessAccountSearchRsDTOv1 rs = new DomainBusinessAccountSearchRsDTOv1();
@@ -85,7 +85,7 @@ public class DomainBusinessAccountListController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/private/domain/business_account/{businessAccountId}/v1")
     public ResponseEntity<?> domainBusinessAccountViewV1(
-            @MapperContextBinding(roots = DomainBusinessAccountDTOMapper.class, response = DomainBusinessAccountViewRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = DomainBusinessAccountDTOMapper.class, response = DomainBusinessAccountViewRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.BUSINESS_ACCOUNT_ID) @PathVariable("businessAccountId") UUID businessAccountId) {
         DomainBusinessAccountViewRsDTOv1 rs = new DomainBusinessAccountViewRsDTOv1();
         try {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/domain/DomainListController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/domain/DomainListController.java
@@ -18,9 +18,8 @@ import org.springframework.web.bind.annotation.RestController;
 import org.twins.core.controller.rest.ApiController;
 import org.twins.core.controller.rest.ApiTag;
 import org.twins.core.controller.rest.annotation.MapperContextBinding;
-import org.twins.core.controller.rest.annotation.ParametersApiUserNoDomainHeaders;
-import org.twins.core.controller.rest.annotation.ProtectedBy;
 import org.twins.core.controller.rest.annotation.ParametersApiUserHeaders;
+import org.twins.core.controller.rest.annotation.ProtectedBy;
 import org.twins.core.controller.rest.annotation.SimplePaginationParams;
 import org.twins.core.dao.domain.DomainEntity;
 import org.twins.core.domain.apiuser.UserResolverAuthToken;
@@ -31,7 +30,6 @@ import org.twins.core.mappers.rest.pagination.PaginationMapper;
 import org.twins.core.mappers.rest.related.RelatedObjectsRestDTOConverter;
 import org.twins.core.service.auth.AuthService;
 import org.twins.core.service.domain.DomainUserService;
-import org.twins.core.service.domain.DomainService;
 import org.twins.core.service.permission.Permissions;
 
 @Tag(description = "", name = ApiTag.DOMAIN)
@@ -56,7 +54,7 @@ public class DomainListController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/private/domain/list/v1")
     public ResponseEntity<?> domainListV1(
-            @MapperContextBinding(roots = DomainViewRestDTOMapper.class, response = DomainListRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = DomainViewRestDTOMapper.class, response = DomainListRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @SimplePaginationParams SimplePagination pagination) {
         DomainListRsDTOv1 rs = new DomainListRsDTOv1();
         try {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/domain/DomainUpdateController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/domain/DomainUpdateController.java
@@ -50,7 +50,7 @@ public class DomainUpdateController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PutMapping(value = "/private/domain/v1")
     public ResponseEntity<?> domainUpdateV1(
-            @MapperContextBinding(roots = DomainViewRestDTOMapper.class, response = DomainViewRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = DomainViewRestDTOMapper.class, response = DomainViewRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @RequestBody DomainUpdateRqDTOv1 request) {
         DomainViewRsDTOv1 rs = new DomainViewRsDTOv1();
         try {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/domain/DomainUserSearchController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/domain/DomainUserSearchController.java
@@ -62,7 +62,7 @@ public class DomainUserSearchController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/domain/user/search/v1")
     public ResponseEntity<?> domainUserSearchListV1(
-            @MapperContextBinding(roots = DomainUserRestDTOMapperV2.class, response = DomainUserSearchRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = DomainUserRestDTOMapperV2.class, response = DomainUserSearchRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @RequestBody DomainUserSearchRqDTOv1 request,
             @SimplePaginationParams SimplePagination pagination) {
         DomainUserSearchRsDTOv1 rs = new DomainUserSearchRsDTOv1();
@@ -91,7 +91,7 @@ public class DomainUserSearchController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/private/domain/user/{userId}/v1")
     public ResponseEntity<?> domainUserViewV1(
-            @MapperContextBinding(roots = DomainUserRestDTOMapperV2.class, response = DomainUserViewRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = DomainUserRestDTOMapperV2.class, response = DomainUserViewRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.USER_ID) @PathVariable("userId") UUID userId) {
         DomainUserViewRsDTOv1 rs = new DomainUserViewRsDTOv1();
         try {
@@ -117,7 +117,7 @@ public class DomainUserSearchController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/private/domain/user/v1")
     public ResponseEntity<?> domainCurrentUserViewV1(
-            @MapperContextBinding(roots = DomainUserRestDTOMapperV2.class, response = DomainUserViewRsDTOv1.class) MapperContext mapperContext) {
+            @MapperContextBinding(roots = DomainUserRestDTOMapperV2.class, response = DomainUserViewRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext) {
         DomainUserViewRsDTOv1 rs = new DomainUserViewRsDTOv1();
         try {
             DomainUserEntity domainUser = domainUserService.getCurrentUser();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/domain/DomainViewController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/domain/DomainViewController.java
@@ -19,9 +19,8 @@ import org.twins.core.controller.rest.ApiController;
 import org.twins.core.controller.rest.ApiTag;
 import org.twins.core.controller.rest.annotation.Loggable;
 import org.twins.core.controller.rest.annotation.MapperContextBinding;
-import org.twins.core.controller.rest.annotation.ParametersApiUserNoDomainHeaders;
-import org.twins.core.controller.rest.annotation.ProtectedBy;
 import org.twins.core.controller.rest.annotation.ParametersApiUserHeaders;
+import org.twins.core.controller.rest.annotation.ProtectedBy;
 import org.twins.core.dao.domain.DomainEntity;
 import org.twins.core.domain.apiuser.UserResolverAuthToken;
 import org.twins.core.dto.rest.DTOExamples;
@@ -57,7 +56,7 @@ public class DomainViewController extends ApiController {
     @GetMapping(value = "/private/domain/{domainId}/v1")
     @Loggable(rsBodyThreshold = 1000)
     public ResponseEntity<?> domainViewV1(
-            @MapperContextBinding(roots = DomainViewRestDTOMapper.class, response = DomainViewRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = DomainViewRestDTOMapper.class, response = DomainViewRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.DOMAIN_ID) @PathVariable UUID domainId) {
 
         DomainViewRsDTOv1 rs = new DomainViewRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/draft/DraftCommitController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/draft/DraftCommitController.java
@@ -48,7 +48,7 @@ public class DraftCommitController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PutMapping(value = "/private/draft/{draftId}/commit/v1")
     public ResponseEntity<?> draftCommitV1(
-            @MapperContextBinding(roots = DraftRestDTOMapper.class, response = DraftRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = DraftRestDTOMapper.class, response = DraftRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.DRAFT_ID) @PathVariable UUID draftId) {
         DraftRsDTOv1 rs = new DraftRsDTOv1();
         try {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/face/FaceViewController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/face/FaceViewController.java
@@ -50,7 +50,7 @@ public class FaceViewController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/private/face/{faceId}/v1")
     public ResponseEntity<?> faceViewV1(
-            @MapperContextBinding(roots = FaceRestDTOMapper.class, response = FaceViewRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = FaceRestDTOMapper.class, response = FaceViewRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.FACE_ID) @PathVariable UUID faceId) {
         FaceViewRsDTOv1 rs = new FaceViewRsDTOv1();
         try {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/factory/FactoryBranchCreateController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/factory/FactoryBranchCreateController.java
@@ -50,7 +50,7 @@ public class FactoryBranchCreateController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/factory/{factoryId}/factory_branch/v1")
     public ResponseEntity<?> factoryBranchCreateV1(
-            @MapperContextBinding(roots = FactoryBranchRestDTOMapperV2.class, response = FactoryBranchRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = FactoryBranchRestDTOMapperV2.class, response = FactoryBranchRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.FACTORY_ID) @PathVariable UUID factoryId,
             @RequestBody FactoryBranchCreateRqDTOv1 request) {
         FactoryBranchRsDTOv1 rs = new FactoryBranchRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/factory/FactoryBranchSearchController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/factory/FactoryBranchSearchController.java
@@ -57,7 +57,7 @@ public class FactoryBranchSearchController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/factory_branch/search/v1")
     public ResponseEntity<?> factoryBranchSearchV1(
-            @MapperContextBinding(roots = FactoryBranchRestDTOMapperV2.class, response = FactoryBranchSearchRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = FactoryBranchRestDTOMapperV2.class, response = FactoryBranchSearchRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @SimplePaginationParams SimplePagination pagination,
             @RequestBody FactoryBranchSearchRqDTOv1 request) {
         FactoryBranchSearchRsDTOv1 rs = new FactoryBranchSearchRsDTOv1();
@@ -85,7 +85,7 @@ public class FactoryBranchSearchController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/private/factory_branch/{factoryBranchId}/v1")
     public ResponseEntity<?> factoryBranchViewV1(
-            @MapperContextBinding(roots = FactoryBranchRestDTOMapperV2.class, response = FactoryBranchViewRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = FactoryBranchRestDTOMapperV2.class, response = FactoryBranchViewRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.FACTORY_BRANCH_ID) @PathVariable("factoryBranchId")UUID factoryBranchId) {
         FactoryBranchViewRsDTOv1 rs = new FactoryBranchViewRsDTOv1();
         try {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/factory/FactoryBranchUpdateController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/factory/FactoryBranchUpdateController.java
@@ -50,7 +50,7 @@ public class FactoryBranchUpdateController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PutMapping(value = "/private/factory_branch/{factoryBranchId}/v1")
     public ResponseEntity<?> factoryBranchUpdateV1(
-            @MapperContextBinding(roots = FactoryBranchRestDTOMapperV2.class, response = FactoryBranchRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = FactoryBranchRestDTOMapperV2.class, response = FactoryBranchRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.FACTORY_BRANCH_ID) @PathVariable UUID factoryBranchId,
             @RequestBody FactoryBranchUpdateRqDTOv1 request) {
         FactoryBranchRsDTOv1 rs = new FactoryBranchRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/factory/FactoryConditionSetSearchController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/factory/FactoryConditionSetSearchController.java
@@ -59,7 +59,7 @@ public class FactoryConditionSetSearchController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/factory_condition_set/search/v1")
     public ResponseEntity<?> factoryConditionSetSearchV1(
-            @MapperContextBinding(roots = FactoryConditionSetRestDTOMapperV2.class, response = FactoryConditionSetSearchRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = FactoryConditionSetRestDTOMapperV2.class, response = FactoryConditionSetSearchRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @SimplePaginationParams SimplePagination pagination,
             @RequestBody FactoryConditionSetSearchRqDTOv1 request) {
         FactoryConditionSetSearchRsDTOv1 rs = new FactoryConditionSetSearchRsDTOv1();
@@ -87,7 +87,7 @@ public class FactoryConditionSetSearchController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/private/factory_condition_set/{factoryConditionSetId}/v1")
     public ResponseEntity<?> factoryConditionSetViewV1(
-            @MapperContextBinding(roots = FactoryConditionSetRestDTOMapper.class, response = FactoryConditionSetViewRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = FactoryConditionSetRestDTOMapper.class, response = FactoryConditionSetViewRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.FACTORY_CONDITION_SET_ID) @PathVariable("factoryConditionSetId") UUID factoryConditionSetId) {
         FactoryConditionSetViewRsDTOv1 rs = new FactoryConditionSetViewRsDTOv1();
         try {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/factory/FactoryCreateController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/factory/FactoryCreateController.java
@@ -52,7 +52,7 @@ public class FactoryCreateController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/factory/v1")
     public ResponseEntity<?> factoryCreateV1(
-            @MapperContextBinding(roots = FactoryRestDTOMapperV2.class, response = FactoryRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = FactoryRestDTOMapperV2.class, response = FactoryRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @RequestBody FactoryCreateRqDTOv1 request) {
         FactoryRsDTOv1 rs = new FactoryRsDTOv1();
         try {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/factory/FactoryEraserCreateController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/factory/FactoryEraserCreateController.java
@@ -50,7 +50,7 @@ public class FactoryEraserCreateController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/factory/{factoryId}/factory_eraser/v1")
     public ResponseEntity<?> factoryEraserCreateV1(
-            @MapperContextBinding(roots = FactoryEraserRestDTOMapperV2.class, response = FactoryEraserSaveRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = FactoryEraserRestDTOMapperV2.class, response = FactoryEraserSaveRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.FACTORY_ID) @PathVariable UUID factoryId,
             @RequestBody FactoryEraserCreateRqDTOv1 request) {
         FactoryEraserSaveRsDTOv1 rs = new FactoryEraserSaveRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/factory/FactoryEraserSearchController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/factory/FactoryEraserSearchController.java
@@ -60,7 +60,7 @@ public class FactoryEraserSearchController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/factory_eraser/search/v1")
     public ResponseEntity<?> factoryEraserSearchV1(
-            @MapperContextBinding(roots = FactoryEraserRestDTOMapperV2.class, response = FactoryEraserSearchRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = FactoryEraserRestDTOMapperV2.class, response = FactoryEraserSearchRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @SimplePaginationParams SimplePagination pagination,
             @RequestBody FactoryEraserSearchRqDTOv1 request) {
         FactoryEraserSearchRsDTOv1 rs = new FactoryEraserSearchRsDTOv1();
@@ -89,7 +89,7 @@ public class FactoryEraserSearchController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/private/factory_eraser/{eraserId}/v1")
     public ResponseEntity<?> factoryEraserViewV1(
-            @MapperContextBinding(roots = FactoryEraserRestDTOMapperV2.class, response = FactoryEraserViewRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = FactoryEraserRestDTOMapperV2.class, response = FactoryEraserViewRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @SimplePaginationParams SimplePagination pagination,
             @Parameter(example = DTOExamples.FACTORY_ERASER_ID) @PathVariable("eraserId") UUID eraserId) {
         FactoryEraserViewRsDTOv1 rs = new FactoryEraserViewRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/factory/FactoryEraserUpdateController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/factory/FactoryEraserUpdateController.java
@@ -50,7 +50,7 @@ public class FactoryEraserUpdateController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PutMapping(value = "/private/factory/factory_eraser/{factoryEraserId}/v1")
     public ResponseEntity<?> factoryEraserUpdateV1(
-            @MapperContextBinding(roots = FactoryEraserRestDTOMapperV2.class, response = FactoryEraserSaveRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = FactoryEraserRestDTOMapperV2.class, response = FactoryEraserSaveRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.FACTORY_ERASER_ID) @PathVariable UUID factoryEraserId,
             @RequestBody FactoryEraserUpdateRqDTOv1 request) {
         FactoryEraserSaveRsDTOv1 rs = new FactoryEraserSaveRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/factory/FactoryMultiplierCreateController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/factory/FactoryMultiplierCreateController.java
@@ -50,7 +50,7 @@ public class FactoryMultiplierCreateController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/factory/{factoryId}/factory_multiplier/v1")
     public ResponseEntity<?> factoryMultiplierCreateV1(
-            @MapperContextBinding(roots = FactoryMultiplierRestDTOMapperV2.class, response = FactoryMultiplierRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = FactoryMultiplierRestDTOMapperV2.class, response = FactoryMultiplierRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.FACTORY_ID) @PathVariable UUID factoryId,
             @RequestBody FactoryMultiplierCreateRqDTOv1 request) {
         FactoryMultiplierRsDTOv1 rs = new FactoryMultiplierRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/factory/FactoryMultiplierFilterSearchController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/factory/FactoryMultiplierFilterSearchController.java
@@ -59,7 +59,7 @@ public class FactoryMultiplierFilterSearchController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/factory_multiplier_filter/search/v1")
     public ResponseEntity<?> factoryMultiplierFilterSearchV1(
-            @MapperContextBinding(roots = FactoryMultiplierFilterRestDTOMapperV2.class, response = FactoryMultiplierFilterSearchRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = FactoryMultiplierFilterRestDTOMapperV2.class, response = FactoryMultiplierFilterSearchRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @SimplePaginationParams SimplePagination pagination,
             @RequestBody FactoryMultiplierFilterSearchRqDTOv1 request) {
         FactoryMultiplierFilterSearchRsDTOv1 rs = new FactoryMultiplierFilterSearchRsDTOv1();
@@ -87,7 +87,7 @@ public class FactoryMultiplierFilterSearchController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/private/factory_multiplier_filter/{multiplierId}/v1")
     public ResponseEntity<?> factoryMultiplierFilterViewV1(
-            @MapperContextBinding(roots = FactoryMultiplierFilterRestDTOMapperV2.class, response = FactoryMultiplierFilterViewRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = FactoryMultiplierFilterRestDTOMapperV2.class, response = FactoryMultiplierFilterViewRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.MULTIPLIER_ID) @PathVariable("multiplierId") UUID multiplierId) {
         FactoryMultiplierFilterViewRsDTOv1 rs = new FactoryMultiplierFilterViewRsDTOv1();
         try {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/factory/FactoryMultiplierSearchController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/factory/FactoryMultiplierSearchController.java
@@ -59,7 +59,7 @@ public class FactoryMultiplierSearchController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/factory_multiplier/search/v1")
     public ResponseEntity<?> factoryMultiplierSearchV1(
-            @MapperContextBinding(roots = FactoryMultiplierRestDTOMapperV2.class, response = FactoryMultiplierSearchRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = FactoryMultiplierRestDTOMapperV2.class, response = FactoryMultiplierSearchRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @SimplePaginationParams SimplePagination pagination,
             @RequestBody FactoryMultiplierSearchRqDTOv1 request) {
         FactoryMultiplierSearchRsDTOv1 rs = new FactoryMultiplierSearchRsDTOv1();
@@ -87,7 +87,7 @@ public class FactoryMultiplierSearchController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/private/factory_multiplier/{multiplierId}/v1")
     public ResponseEntity<?> factoryMultiplierViewV1(
-            @MapperContextBinding(roots = FactoryMultiplierRestDTOMapperV2.class, response = FactoryMultiplierViewRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = FactoryMultiplierRestDTOMapperV2.class, response = FactoryMultiplierViewRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.MULTIPLIER_ID) @PathVariable("multiplierId") UUID multiplierId) {
         FactoryMultiplierViewRsDTOv1 rs = new FactoryMultiplierViewRsDTOv1();
         try {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/factory/FactoryMultiplierUpdateController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/factory/FactoryMultiplierUpdateController.java
@@ -50,7 +50,7 @@ public class FactoryMultiplierUpdateController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PutMapping(value = "/private/factory_multiplier/{factoryMultiplierId}/v1")
     public ResponseEntity<?> factoryMultiplierUpdateV1(
-            @MapperContextBinding(roots = FactoryMultiplierRestDTOMapperV2.class, response = FactoryMultiplierRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = FactoryMultiplierRestDTOMapperV2.class, response = FactoryMultiplierRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.FACTORY_MULTIPLIER_ID) @PathVariable UUID factoryMultiplierId,
             @RequestBody FactoryMultiplierUpdateRqDTOv1 request) {
         FactoryMultiplierRsDTOv1 rs = new FactoryMultiplierRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/factory/FactoryPipelineCreateController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/factory/FactoryPipelineCreateController.java
@@ -50,7 +50,7 @@ public class FactoryPipelineCreateController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/factory/{factoryId}/factory_pipeline/v1")
     public ResponseEntity<?> factoryPipelineCreateV1(
-            @MapperContextBinding(roots = FactoryPipelineRestDTOMapperV2.class, response = FactoryPipelineRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = FactoryPipelineRestDTOMapperV2.class, response = FactoryPipelineRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.FACTORY_ID) @PathVariable UUID factoryId,
             @RequestBody FactoryPipelineCreateRqDTOv1 request) {
         FactoryPipelineRsDTOv1 rs = new FactoryPipelineRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/factory/FactoryPipelineSearchController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/factory/FactoryPipelineSearchController.java
@@ -59,7 +59,7 @@ public class FactoryPipelineSearchController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/factory_pipeline/search/v1")
     public ResponseEntity<?> factoryPipelineSearchV1(
-            @MapperContextBinding(roots = FactoryPipelineRestDTOMapperV2.class, response = FactoryPipelineSearchRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = FactoryPipelineRestDTOMapperV2.class, response = FactoryPipelineSearchRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @SimplePaginationParams SimplePagination pagination,
             @RequestBody FactoryPipelineSearchRqDTOv1 request) {
         FactoryPipelineSearchRsDTOv1 rs = new FactoryPipelineSearchRsDTOv1();
@@ -87,7 +87,7 @@ public class FactoryPipelineSearchController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/private/factory_pipeline/{pipelineId}/v1")
     public ResponseEntity<?> factoryPipelineViewV1(
-            @MapperContextBinding(roots = FactoryPipelineRestDTOMapperV2.class, response = FactoryPipelineViewRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = FactoryPipelineRestDTOMapperV2.class, response = FactoryPipelineViewRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.FACTORY_PIPELINE_ID) @PathVariable("pipelineId") UUID pipelineId) {
         FactoryPipelineViewRsDTOv1 rs = new FactoryPipelineViewRsDTOv1();
         try {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/factory/FactoryPipelineStepCreateController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/factory/FactoryPipelineStepCreateController.java
@@ -50,7 +50,7 @@ public class FactoryPipelineStepCreateController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/factory/factory_pipeline/{factoryPipelineId}/factory_pipeline_step/v1")
     public ResponseEntity<?> factoryPipelineStepCreateV1(
-            @MapperContextBinding(roots = FactoryPipelineStepRestDTOMapperV2.class, response = FactoryPipelineStepSaveRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = FactoryPipelineStepRestDTOMapperV2.class, response = FactoryPipelineStepSaveRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.FACTORY_PIPELINE_ID) @PathVariable UUID factoryPipelineId,
             @RequestBody FactoryPipelineStepCreateRqDTOv1 request) {
         FactoryPipelineStepSaveRsDTOv1 rs = new FactoryPipelineStepSaveRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/factory/FactoryPipelineStepSearchController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/factory/FactoryPipelineStepSearchController.java
@@ -58,7 +58,7 @@ public class FactoryPipelineStepSearchController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/factory_pipeline_step/search/v1")
     public ResponseEntity<?> factoryPipelineStepSearchV1(
-            @MapperContextBinding(roots = FactoryPipelineStepRestDTOMapperV2.class, response = FactoryPipelineStepSearchRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = FactoryPipelineStepRestDTOMapperV2.class, response = FactoryPipelineStepSearchRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @SimplePaginationParams SimplePagination pagination,
             @RequestBody FactoryPipelineStepSearchRqDTOv1 request) {
         FactoryPipelineStepSearchRsDTOv1 rs = new FactoryPipelineStepSearchRsDTOv1();
@@ -86,7 +86,7 @@ public class FactoryPipelineStepSearchController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/private/factory_pipeline_step/{stepId}/v1")
     public ResponseEntity<?> factoryPipelineStepViewV1(
-            @MapperContextBinding(roots = FactoryPipelineStepRestDTOMapperV2.class, response = FactoryPipelineStepViewRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = FactoryPipelineStepRestDTOMapperV2.class, response = FactoryPipelineStepViewRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.FACTORY_PIPELINE_STEP_ID) @PathVariable("stepId") UUID stepId) {
         FactoryPipelineStepViewRsDTOv1 rs = new FactoryPipelineStepViewRsDTOv1();
         try {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/factory/FactoryPipelineStepUpdateController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/factory/FactoryPipelineStepUpdateController.java
@@ -50,7 +50,7 @@ public class FactoryPipelineStepUpdateController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PutMapping(value = "/private/factory/factory_pipeline_step/{factoryPipelineStepId}/v1")
     public ResponseEntity<?> factoryPipelineStepUpdateV1(
-            @MapperContextBinding(roots = FactoryPipelineStepRestDTOMapperV2.class, response = FactoryPipelineStepSaveRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = FactoryPipelineStepRestDTOMapperV2.class, response = FactoryPipelineStepSaveRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.FACTORY_PIPELINE_STEP_ID) @PathVariable UUID factoryPipelineStepId,
             @RequestBody FactoryPipelineStepUpdateRqDTOv1 request) {
         FactoryPipelineStepSaveRsDTOv1 rs = new FactoryPipelineStepSaveRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/factory/FactoryPipelineUpdateController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/factory/FactoryPipelineUpdateController.java
@@ -50,7 +50,7 @@ public class FactoryPipelineUpdateController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PutMapping(value = "/private/factory_pipeline/{factoryPipelineId}/v1")
     public ResponseEntity<?> factoryPipelineUpdateV1(
-            @MapperContextBinding(roots = FactoryPipelineRestDTOMapperV2.class, response = FactoryPipelineRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = FactoryPipelineRestDTOMapperV2.class, response = FactoryPipelineRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.FACTORY_PIPELINE_ID) @PathVariable UUID factoryPipelineId,
             @RequestBody FactoryPipelineUpdateRqDTOv1 request) {
         FactoryPipelineRsDTOv1 rs = new FactoryPipelineRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/factory/FactorySearchController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/factory/FactorySearchController.java
@@ -58,7 +58,7 @@ public class FactorySearchController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/factory/search/v1")
     public ResponseEntity<?> factorySearchListV1(
-            @MapperContextBinding(roots = FactoryRestDTOMapperV2.class, response = FactorySearchRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = FactoryRestDTOMapperV2.class, response = FactorySearchRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @SimplePaginationParams SimplePagination pagination,
             @RequestBody FactorySearchRqDTOv1 request) {
         FactorySearchRsDTOv1 rs = new FactorySearchRsDTOv1();
@@ -86,7 +86,7 @@ public class FactorySearchController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/private/factory/{factoryId}/v1")
     public ResponseEntity<?> factoryViewV1(
-            @MapperContextBinding(roots = FactoryRestDTOMapperV2.class, response = FactoryViewRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = FactoryRestDTOMapperV2.class, response = FactoryViewRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.FACTORY_ID) @PathVariable("factoryId") UUID factoryId) {
         FactoryViewRsDTOv1 rs = new FactoryViewRsDTOv1();
         try {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/factory/FactoryUpdateController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/factory/FactoryUpdateController.java
@@ -53,7 +53,7 @@ public class FactoryUpdateController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PutMapping(value = "/private/factory/{factoryId}/v1")
     public ResponseEntity<?> factoryUpdateV1(
-            @MapperContextBinding(roots = FactoryRestDTOMapperV2.class, response = FactoryRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = FactoryRestDTOMapperV2.class, response = FactoryRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.FACTORY_ID) @PathVariable UUID factoryId,
             @RequestBody FactoryUpdateRqDTOv1 request) {
         FactoryRsDTOv1 rs = new FactoryRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/history/HistoryListController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/history/HistoryListController.java
@@ -60,7 +60,7 @@ public class HistoryListController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/private/twin/{twinId}/history/list/v1")
     public ResponseEntity<?> historyListV1(
-            @MapperContextBinding(roots = HistoryDTOMapperV1.class, response = HistoryListRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = HistoryDTOMapperV1.class, response = HistoryListRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.TWIN_ID) @PathVariable UUID twinId,
             @RequestParam(name = RestRequestParam.childDepth, defaultValue = "0") int childDepth,
             @SimplePaginationParams(sortAsc = false, sortField = HistoryEntity.Fields.createdAt) SimplePagination pagination) {
@@ -88,7 +88,7 @@ public class HistoryListController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/twin/history/search/v1")
     public ResponseEntity<?> historySearchV1(
-            @MapperContextBinding(roots = HistoryDTOMapperV1.class, response = HistorySearchRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = HistoryDTOMapperV1.class, response = HistorySearchRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @SimplePaginationParams(sortAsc = false, sortField = HistoryEntity.Fields.createdAt) SimplePagination pagination,
             @RequestBody HistorySearchRqDTOv1 request) {
         HistorySearchRsDTOv1 rs = new HistorySearchRsDTOv1();
@@ -117,7 +117,7 @@ public class HistoryListController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/private/twin/history/{historyId}/v1")
     public ResponseEntity<?> historyViewV1(
-            @MapperContextBinding(roots = HistoryDTOMapperV1.class, response = HistoryViewRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = HistoryDTOMapperV1.class, response = HistoryViewRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.TWIN_HISTORY_ID) @PathVariable("historyId") UUID historyId) {
         HistoryViewRsDTOv1 rs = new HistoryViewRsDTOv1();
         try {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/i18n/I18nTranslationSearchController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/i18n/I18nTranslationSearchController.java
@@ -56,7 +56,7 @@ public class I18nTranslationSearchController extends ApiController {
     })
     @PostMapping(value = "/private/i18n_translation/search/v1")
     public ResponseEntity<?> i18nTranslationSearchV1(
-            @MapperContextBinding(roots = I18nTranslationRestDTOMapper.class, response = I18nTranslationListRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = I18nTranslationRestDTOMapper.class, response = I18nTranslationListRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @RequestBody I18nTranslationSearchDTOv1 request,
             @SimplePaginationParams SimplePagination pagination) {
         I18nTranslationListRsDTOv1 rs = new I18nTranslationListRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/i18n/I18nTranslationUpdateController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/i18n/I18nTranslationUpdateController.java
@@ -51,7 +51,7 @@ public class I18nTranslationUpdateController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PutMapping(value = "/private/i18n_translation/v1")
     public ResponseEntity<?> i18nTranslationUpdateV1(
-            @MapperContextBinding(roots = I18nTranslationRestDTOMapper.class, response = I18nTranslationListRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = I18nTranslationRestDTOMapper.class, response = I18nTranslationListRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @RequestBody I18nTranslationUpdateRqDTOv1 request) {
         I18nTranslationListRsDTOv1 rs = new I18nTranslationListRsDTOv1();
         try {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/i18n/I18nViewController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/i18n/I18nViewController.java
@@ -48,7 +48,7 @@ public class I18nViewController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/private/i18n/{i18nId}/v1")
     public ResponseEntity<?> i18nViewV1(
-            @MapperContextBinding(roots = I18nRestDTOMapper.class, response = I18nViewRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = I18nRestDTOMapper.class, response = I18nViewRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.I18N_ID) @PathVariable UUID i18nId) {
         I18nViewRsDTOv1 rs = new I18nViewRsDTOv1();
         try {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/link/LinkCreateController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/link/LinkCreateController.java
@@ -53,7 +53,7 @@ public class LinkCreateController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/link/v1")
     public ResponseEntity<?> linkCreateV1(
-            @MapperContextBinding(roots = {LinkForwardRestDTOV3Mapper.class}, response = LinkCreateRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = {LinkForwardRestDTOV3Mapper.class}, response = LinkCreateRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @RequestBody LinkCreateDTOv1 request) {
         LinkCreateRsDTOv1 rs = new LinkCreateRsDTOv1();
         try {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/link/LinkSearchController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/link/LinkSearchController.java
@@ -58,7 +58,7 @@ public class LinkSearchController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/link/search/v1")
     public ResponseEntity<?> linkSearchV1(
-            @MapperContextBinding(roots = LinkForwardRestDTOV3Mapper.class, response = LinkSearchRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = LinkForwardRestDTOV3Mapper.class, response = LinkSearchRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @SimplePaginationParams SimplePagination pagination,
             @RequestBody LinkSearchRqDTOv1 request) {
         LinkSearchRsDTOv1 rs = new LinkSearchRsDTOv1();
@@ -86,7 +86,7 @@ public class LinkSearchController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/private/link/{linkId}/v1")
     public ResponseEntity<?> linkViewV1(
-            @MapperContextBinding(roots = LinkForwardRestDTOV3Mapper.class, response = LinkViewRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = LinkForwardRestDTOV3Mapper.class, response = LinkViewRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.LINK_ID) @PathVariable("linkId") UUID linkId) {
         LinkViewRsDTOv1 rs = new LinkViewRsDTOv1();
         try {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/link/LinkUpdateController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/link/LinkUpdateController.java
@@ -55,7 +55,7 @@ public class LinkUpdateController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PutMapping(value = "/private/link/{linkId}/v1")
     public ResponseEntity<?> linkUpdateV1(
-            @MapperContextBinding(roots = {LinkForwardRestDTOV3Mapper.class}, response = LinkUpdateRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = {LinkForwardRestDTOV3Mapper.class}, response = LinkUpdateRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.LINK_ID) @PathVariable UUID linkId,
             @RequestBody LinkUpdateDTOv1 request) {
         LinkUpdateRsDTOv1 rs = new LinkUpdateRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/link/TwinClassLinkListController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/link/TwinClassLinkListController.java
@@ -52,7 +52,7 @@ public class TwinClassLinkListController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/private/twin_class/{twinClassId}/link/v1")
     public ResponseEntity<?> twinClassLinkListV1(
-            @MapperContextBinding(roots = {LinkForwardRestDTOMapper.class, LinkBackwardRestDTOMapper.class}, response = LinkListRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = {LinkForwardRestDTOMapper.class, LinkBackwardRestDTOMapper.class}, response = LinkListRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.TWIN_CLASS_ID) @PathVariable UUID twinClassId) {
         LinkListRsDTOv1 rs = new LinkListRsDTOv1();
         try {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/permission/PermissionCreateController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/permission/PermissionCreateController.java
@@ -50,7 +50,7 @@ public class PermissionCreateController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/permission/v1")
     public ResponseEntity<?> permissionCreateV1(
-            @MapperContextBinding(roots = PermissionRestDTOMapper.class, response = PermissionCreateRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = PermissionRestDTOMapper.class, response = PermissionCreateRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @RequestBody PermissionCreateRqDTOv1 request) {
         PermissionCreateRsDTOv1 rs = new PermissionCreateRsDTOv1();
         try {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/permission/PermissionGrantAssigneePropagationCreateController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/permission/PermissionGrantAssigneePropagationCreateController.java
@@ -49,7 +49,7 @@ public class PermissionGrantAssigneePropagationCreateController extends ApiContr
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/permission_grant/assignee_propagation/v1")
     public ResponseEntity<?> permissionGrantAssigneePropagationCreateV1(
-            @MapperContextBinding(roots = PermissionGrantAssigneePropagationRestDTOMapperV2.class, response = PermissionGrantAssigneePropagationRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = PermissionGrantAssigneePropagationRestDTOMapperV2.class, response = PermissionGrantAssigneePropagationRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @RequestBody PermissionGrantAssigneePropagationCreateRqDTOv1 request) {
         PermissionGrantAssigneePropagationRsDTOv1 rs = new PermissionGrantAssigneePropagationRsDTOv1();
         try {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/permission/PermissionGrantAssigneePropagationSearchController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/permission/PermissionGrantAssigneePropagationSearchController.java
@@ -59,7 +59,7 @@ public class PermissionGrantAssigneePropagationSearchController extends ApiContr
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/permission_grant/assignee_propagation/search/v1")
     public ResponseEntity<?> permissionGrantAssigneePropagationSearchV1(
-            @MapperContextBinding(roots = PermissionGrantAssigneePropagationRestDTOMapperV2.class, response = PermissionGrantAssigneePropagationSearchRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = PermissionGrantAssigneePropagationRestDTOMapperV2.class, response = PermissionGrantAssigneePropagationSearchRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @SimplePaginationParams SimplePagination pagination,
             @RequestBody PermissionGrantAssigneePropagationSearchRqDTOv1 request) {
         PermissionGrantAssigneePropagationSearchRsDTOv1 rs = new PermissionGrantAssigneePropagationSearchRsDTOv1();
@@ -87,7 +87,7 @@ public class PermissionGrantAssigneePropagationSearchController extends ApiContr
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/private/permission_grant/assignee_propagation/{grantId}/v1")
     public ResponseEntity<?> permissionGrantAssigneePropagationViewV1(
-            @MapperContextBinding(roots = PermissionGrantAssigneePropagationRestDTOMapperV2.class, response = PermissionGrantAssigneePropagationViewRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = PermissionGrantAssigneePropagationRestDTOMapperV2.class, response = PermissionGrantAssigneePropagationViewRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.PERMISSION_GRANT_ASSIGNEE_PROPAGATION_ID) @PathVariable("grantId") UUID grentId) {
         PermissionGrantAssigneePropagationViewRsDTOv1 rs = new PermissionGrantAssigneePropagationViewRsDTOv1();
         try {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/permission/PermissionGrantAssigneePropagationUpdateController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/permission/PermissionGrantAssigneePropagationUpdateController.java
@@ -50,7 +50,7 @@ public class PermissionGrantAssigneePropagationUpdateController extends ApiContr
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PutMapping(value = "/private/permission_grant/assingee_propagation/{permissionGrantAssigneePropagationId}/v1")
     public ResponseEntity<?> permissionGrantAssigneePropagationUpdateV1(
-            @MapperContextBinding(roots = PermissionGrantAssigneePropagationRestDTOMapperV2.class, response = PermissionGrantAssigneePropagationRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = PermissionGrantAssigneePropagationRestDTOMapperV2.class, response = PermissionGrantAssigneePropagationRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.PERMISSION_GRANT_ASSIGNEE_PROPAGATION_ID) @PathVariable UUID permissionGrantAssigneePropagationId,
             @RequestBody PermissionGrantAssigneePropagationUpdateRqDTOv1 request) {
 

--- a/core/src/main/java/org/twins/core/controller/rest/priv/permission/PermissionGrantSpaceRoleCreateController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/permission/PermissionGrantSpaceRoleCreateController.java
@@ -50,7 +50,7 @@ public class PermissionGrantSpaceRoleCreateController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/permission_grant/space_role/v1")
     public ResponseEntity<?> permissionGrantSpaceRoleCreateV1(
-            @MapperContextBinding(roots = PermissionGrantSpaceRoleRestDTOMapperV2.class, response = PermissionGrantSpaceRoleRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = PermissionGrantSpaceRoleRestDTOMapperV2.class, response = PermissionGrantSpaceRoleRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @RequestBody PermissionGrantSpaceRoleCreateRqDTOv1 request, ServletRequest servletRequest) {
         PermissionGrantSpaceRoleRsDTOv1 rs = new PermissionGrantSpaceRoleRsDTOv1();
         try {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/permission/PermissionGrantSpaceRoleSearchController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/permission/PermissionGrantSpaceRoleSearchController.java
@@ -59,7 +59,7 @@ public class PermissionGrantSpaceRoleSearchController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/permission_grant/space_role/search/v1")
     public ResponseEntity<?> permissionGrantSpaceRoleSearchV1(
-            @MapperContextBinding(roots = PermissionGrantSpaceRoleRestDTOMapperV2.class, response = PermissionGrantSpaceRoleSearchRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = PermissionGrantSpaceRoleRestDTOMapperV2.class, response = PermissionGrantSpaceRoleSearchRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @SimplePaginationParams SimplePagination pagination,
             @RequestBody PermissionGrantSpaceRoleSearchRqDTOv1 request) {
         PermissionGrantSpaceRoleSearchRsDTOv1 rs = new PermissionGrantSpaceRoleSearchRsDTOv1();
@@ -87,7 +87,7 @@ public class PermissionGrantSpaceRoleSearchController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/private/permission_grant/space_role/{grantId}/v1")
     public ResponseEntity<?> permissionGrantSpaceRoleViewV1(
-            @MapperContextBinding(roots = PermissionGrantSpaceRoleRestDTOMapperV2.class, response = PermissionGrantSpaceRoleViewRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = PermissionGrantSpaceRoleRestDTOMapperV2.class, response = PermissionGrantSpaceRoleViewRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.SPACE_ROLE_USER_ID) @PathVariable("grantId") UUID grantId) {
         PermissionGrantSpaceRoleViewRsDTOv1 rs = new PermissionGrantSpaceRoleViewRsDTOv1();
         try {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/permission/PermissionGrantSpaceRoleUpdateController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/permission/PermissionGrantSpaceRoleUpdateController.java
@@ -50,7 +50,7 @@ public class PermissionGrantSpaceRoleUpdateController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PutMapping(value = "/private/permission_grant/space_role/{permissionGrantSpaceRoleId}/v1")
     public ResponseEntity<?> permissionGrantSpaceRoleV1(
-            @MapperContextBinding(roots = PermissionGrantSpaceRoleRestDTOMapperV2.class, response = PermissionGrantSpaceRoleRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = PermissionGrantSpaceRoleRestDTOMapperV2.class, response = PermissionGrantSpaceRoleRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.PERMISSION_GRANT_SPACE_ROLE_ID) @PathVariable UUID permissionGrantSpaceRoleId,
             @RequestBody PermissionGrantSpaceRoleUpdateRqDTOv1 request) {
 

--- a/core/src/main/java/org/twins/core/controller/rest/priv/permission/PermissionGrantTwinRoleCreateController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/permission/PermissionGrantTwinRoleCreateController.java
@@ -49,7 +49,7 @@ public class PermissionGrantTwinRoleCreateController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/permission_grant/twin_role/v1")
     public ResponseEntity<?> permissionGrantTwinRoleCreateV1(
-            @MapperContextBinding(roots = PermissionGrantTwinRoleRestDTOMapperV2.class, response = PermissionGrantTwinRoleRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = PermissionGrantTwinRoleRestDTOMapperV2.class, response = PermissionGrantTwinRoleRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @RequestBody PermissionGrantTwinRoleCreateRqDTOv1 request) {
         PermissionGrantTwinRoleRsDTOv1 rs = new PermissionGrantTwinRoleRsDTOv1();
         try {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/permission/PermissionGrantTwinRoleSearchController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/permission/PermissionGrantTwinRoleSearchController.java
@@ -58,7 +58,7 @@ public class PermissionGrantTwinRoleSearchController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/permission_grant/twin_role/search/v1")
     public ResponseEntity<?> permissionGrantTwinRoleSearchV1(
-            @MapperContextBinding(roots = PermissionGrantTwinRoleRestDTOMapperV2.class, response = PermissionGrantTwinRoleSearchRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = PermissionGrantTwinRoleRestDTOMapperV2.class, response = PermissionGrantTwinRoleSearchRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @SimplePaginationParams SimplePagination pagination,
             @RequestBody PermissionGrantTwinRoleSearchRqDTOv1 request) {
         PermissionGrantTwinRoleSearchRsDTOv1 rs = new PermissionGrantTwinRoleSearchRsDTOv1();
@@ -86,7 +86,7 @@ public class PermissionGrantTwinRoleSearchController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/private/permission_grant/twin_role/{grantId}/v1")
     public ResponseEntity<?> permissionGrantTwinRoleViewV1(
-            @MapperContextBinding(roots = PermissionGrantTwinRoleRestDTOMapperV2.class, response = PermissionGrantTwinRoleViewRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = PermissionGrantTwinRoleRestDTOMapperV2.class, response = PermissionGrantTwinRoleViewRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.PERMISSION_GRANT_TWIN_ROLE_ID) @PathVariable("grantId") UUID grantId) {
         PermissionGrantTwinRoleViewRsDTOv1 rs = new PermissionGrantTwinRoleViewRsDTOv1();
         try {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/permission/PermissionGrantTwinRoleUpdateController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/permission/PermissionGrantTwinRoleUpdateController.java
@@ -50,7 +50,7 @@ public class PermissionGrantTwinRoleUpdateController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PutMapping(value = "/private/permission_grant/twin_role/{permissionGrantTwinRoleId}/v1")
     public ResponseEntity<?> permissionGrantTwinRoleV1(
-            @MapperContextBinding(roots = PermissionGrantTwinRoleRestDTOMapperV2.class, response = PermissionGrantTwinRoleRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = PermissionGrantTwinRoleRestDTOMapperV2.class, response = PermissionGrantTwinRoleRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.PERMISSION_GRANT_TWIN_ROLE_ID) @PathVariable UUID permissionGrantTwinRoleId,
             @RequestBody PermissionGrantTwinRoleUpdateRqDTOv1 request) {
 

--- a/core/src/main/java/org/twins/core/controller/rest/priv/permission/PermissionGrantUserCreateController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/permission/PermissionGrantUserCreateController.java
@@ -50,7 +50,7 @@ public class PermissionGrantUserCreateController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/permission_grant/user/v1")
     public ResponseEntity<?> permissionGrantUserCreateV1(
-            @MapperContextBinding(roots = FactoryEraserRestDTOMapperV2.class, response = PermissionGrantUserSaveRsDTOV1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = FactoryEraserRestDTOMapperV2.class, response = PermissionGrantUserSaveRsDTOV1.class) @Schema(hidden = true) MapperContext mapperContext,
             @RequestBody PermissionGrantUserCreateRqDTOv1 request) {
         PermissionGrantUserSaveRsDTOV1 rs = new PermissionGrantUserSaveRsDTOV1();
         try {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/permission/PermissionGrantUserGroupCreateController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/permission/PermissionGrantUserGroupCreateController.java
@@ -50,7 +50,7 @@ public class PermissionGrantUserGroupCreateController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/permission_grant/user_group/v1")
     public ResponseEntity<?> permissionGrantUserGroupCreateV1(
-            @MapperContextBinding(roots = PermissionGrantUserGroupRestDTOMapperV2.class, response = PermissionGrantUserGroupSaveRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = PermissionGrantUserGroupRestDTOMapperV2.class, response = PermissionGrantUserGroupSaveRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @RequestBody PermissionGrantUserGroupCreateRqDTOv1 request) {
         PermissionGrantUserGroupSaveRsDTOv1 rs = new PermissionGrantUserGroupSaveRsDTOv1();
         try {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/permission/PermissionGrantUserGroupSearchController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/permission/PermissionGrantUserGroupSearchController.java
@@ -60,7 +60,7 @@ public class PermissionGrantUserGroupSearchController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/permission_grant/user_group/search/v1")
     public ResponseEntity<?> permissionGrantUserGroupSearchV1(
-            @MapperContextBinding(roots = PermissionGrantUserGroupRestDTOMapperV2.class, response = PermissionGrantUserGroupSearchRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = PermissionGrantUserGroupRestDTOMapperV2.class, response = PermissionGrantUserGroupSearchRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @SimplePaginationParams SimplePagination pagination,
             @RequestBody PermissionGrantUserGroupSearchRqDTOv1 request) {
         PermissionGrantUserGroupSearchRsDTOv1 rs = new PermissionGrantUserGroupSearchRsDTOv1();
@@ -88,7 +88,7 @@ public class PermissionGrantUserGroupSearchController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/private/permission_grant/user_group/{grantId}/v1")
     public ResponseEntity<?> permissionGrantUserGroupViewV1(
-            @MapperContextBinding(roots = PermissionGrantUserGroupRestDTOMapperV2.class, response = PermissionGrantUserGroupViewRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = PermissionGrantUserGroupRestDTOMapperV2.class, response = PermissionGrantUserGroupViewRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.PERMISSION_GRANT_USER_GROUP_ID) @PathVariable("grantId") UUID grantId) {
         PermissionGrantUserGroupViewRsDTOv1 rs = new PermissionGrantUserGroupViewRsDTOv1();
         try {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/permission/PermissionGrantUserGroupUpdateController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/permission/PermissionGrantUserGroupUpdateController.java
@@ -50,7 +50,7 @@ public class PermissionGrantUserGroupUpdateController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PutMapping(value = "/private/permission_grant/user_group/{permissionGrantUserGroupId}/v1")
     public ResponseEntity<?> permissionGrantUserGroupUpdateV1(
-            @MapperContextBinding(roots = PermissionGrantUserGroupRestDTOMapperV2.class, response = PermissionGrantUserGroupSaveRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = PermissionGrantUserGroupRestDTOMapperV2.class, response = PermissionGrantUserGroupSaveRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.PERMISSION_GRANT_USER_GROUP_ID) @PathVariable UUID permissionGrantUserGroupId,
             @RequestBody PermissionGrantUserGroupUpdateRqDTOv1 request) {
         PermissionGrantUserGroupSaveRsDTOv1 rs = new PermissionGrantUserGroupSaveRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/permission/PermissionGrantUserSearchController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/permission/PermissionGrantUserSearchController.java
@@ -58,7 +58,7 @@ public class PermissionGrantUserSearchController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/permission_grant/user/search/v1")
     public ResponseEntity<?> permissionGrantUserSearchV1(
-            @MapperContextBinding(roots = PermissionGrantUserRestDTOMapperV2.class, response = PermissionGrantUserSearchRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = PermissionGrantUserRestDTOMapperV2.class, response = PermissionGrantUserSearchRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @SimplePaginationParams SimplePagination pagination,
             @RequestBody PermissionGrantUserSearchRqDTOv1 request) {
         PermissionGrantUserSearchRsDTOv1 rs = new PermissionGrantUserSearchRsDTOv1();
@@ -87,7 +87,7 @@ public class PermissionGrantUserSearchController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/permission_grant/user/{grantId}/v1")
     public ResponseEntity<?> permissionGrantUserViewV1(
-            @MapperContextBinding(roots = PermissionGrantUserRestDTOMapperV2.class, response = PermissionGrantUserViewRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = PermissionGrantUserRestDTOMapperV2.class, response = PermissionGrantUserViewRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.PERMISSION_GRANT_USER_ID) @PathVariable("grantId") UUID grantId) {
 
         PermissionGrantUserViewRsDTOv1 rs = new PermissionGrantUserViewRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/permission/PermissionGrantUserUpdateController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/permission/PermissionGrantUserUpdateController.java
@@ -52,7 +52,7 @@ public class PermissionGrantUserUpdateController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PutMapping(value = "/private/permission_grant/user/{permissionGrantUserId}/v1")
     public ResponseEntity<?> permissionGrantUserUpdateV1(
-            @MapperContextBinding(roots = FactoryEraserRestDTOMapperV2.class, response = FactoryEraserSaveRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = FactoryEraserRestDTOMapperV2.class, response = FactoryEraserSaveRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.PERMISSION_GRANT_USER_ID) @PathVariable UUID permissionGrantUserId,
             @RequestBody PermissionGrantUserUpdateRqDTOv1 request) {
         PermissionGrantUserSaveRsDTOV1 rs = new PermissionGrantUserSaveRsDTOV1();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/permission/PermissionGroupSearchController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/permission/PermissionGroupSearchController.java
@@ -59,7 +59,7 @@ public class PermissionGroupSearchController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/permission_group/search/v1")
     public ResponseEntity<?> permissionGroupSearchListV1(
-            @MapperContextBinding(roots = PermissionGroupRestDTOMapper.class, response = PermissionGroupSearchRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = PermissionGroupRestDTOMapper.class, response = PermissionGroupSearchRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @SimplePaginationParams SimplePagination pagination,
             @RequestBody PermissionGroupSearchRqDTOv1 request) {
         PermissionGroupSearchRsDTOv1 rs = new PermissionGroupSearchRsDTOv1();
@@ -87,7 +87,7 @@ public class PermissionGroupSearchController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/private/permission_group/{groupId}/v1")
     public ResponseEntity<?> permissionGroupViewV1(
-            @MapperContextBinding(roots = PermissionGroupRestDTOMapper.class, response = PermissionGroupViewRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = PermissionGroupRestDTOMapper.class, response = PermissionGroupViewRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.PERMISSION_GROUP_ID) @PathVariable("groupId") UUID groupId) {
         PermissionGroupViewRsDTOv1 rs = new PermissionGroupViewRsDTOv1();
         try {
@@ -115,7 +115,7 @@ public class PermissionGroupSearchController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/private/permission_group_by_key/{groupKey}/v1")
     public ResponseEntity<?> permissionGroupViewByKeyV1(
-            @MapperContextBinding(roots = PermissionGroupRestDTOMapper.class, response = PermissionGroupViewRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = PermissionGroupRestDTOMapper.class, response = PermissionGroupViewRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.PERMISSION_GROUP_KEY) @PathVariable("groupKey") String groupKey) {
         PermissionGroupViewRsDTOv1 rs = new PermissionGroupViewRsDTOv1();
         try {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/permission/PermissionSchemaSearchController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/permission/PermissionSchemaSearchController.java
@@ -58,7 +58,7 @@ public class PermissionSchemaSearchController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/permission_schema/search/v1")
     public ResponseEntity<?> permissionSchemaSearchV1(
-            @MapperContextBinding(roots = PermissionSchemaRestDTOMapperV2.class, response = PermissionSchemaSearchRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = PermissionSchemaRestDTOMapperV2.class, response = PermissionSchemaSearchRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @SimplePaginationParams SimplePagination pagination,
             @RequestBody PermissionSchemaSearchRqDTOv1 request) {
         PermissionSchemaSearchRsDTOv1 rs = new PermissionSchemaSearchRsDTOv1();
@@ -86,7 +86,7 @@ public class PermissionSchemaSearchController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/private/permission_schema/{schemaId}/v1")
     public ResponseEntity<?> permissionSchemaViewV1(
-            @MapperContextBinding(roots = PermissionSchemaRestDTOMapperV2.class, response = PermissionSchemaViewRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = PermissionSchemaRestDTOMapperV2.class, response = PermissionSchemaViewRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.PERMISSION_SCHEMA_ID) @PathVariable("schemaId") UUID schemaId) {
         PermissionSchemaViewRsDTOv1 rs = new PermissionSchemaViewRsDTOv1();
         try {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/permission/PermissionSearchController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/permission/PermissionSearchController.java
@@ -58,7 +58,7 @@ public class PermissionSearchController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/permission/search/v1")
     public ResponseEntity<?> permissionSearchListV1(
-            @MapperContextBinding(roots = PermissionRestDTOMapperV2.class, response = PermissionSearchRsDTOv2.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = PermissionRestDTOMapperV2.class, response = PermissionSearchRsDTOv2.class) @Schema(hidden = true) MapperContext mapperContext,
             @RequestBody PermissionSearchRqDTOv1 request,
             @SimplePaginationParams SimplePagination pagination) {
         PermissionSearchRsDTOv2 rs = new PermissionSearchRsDTOv2();
@@ -86,7 +86,7 @@ public class PermissionSearchController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/private/permission/{permissionId}/v1")
     public ResponseEntity<?> permissionViewV1(
-            @MapperContextBinding(roots = PermissionRestDTOMapperV2.class, response = PermissionViewRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = PermissionRestDTOMapperV2.class, response = PermissionViewRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.PERMISSION_ID) @PathVariable("permissionId") UUID permissionId) {
         PermissionViewRsDTOv1 rs = new PermissionViewRsDTOv1();
         try {
@@ -111,7 +111,7 @@ public class PermissionSearchController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/private/permission_by_key/{permissionKey}/v1")
     public ResponseEntity<?> permissionViewByKeyV1(
-            @MapperContextBinding(roots = PermissionRestDTOMapperV2.class, response = PermissionViewRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = PermissionRestDTOMapperV2.class, response = PermissionViewRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.PERMISSION_KEY) @PathVariable("permissionKey") String permissionKey) {
         PermissionViewRsDTOv1 rs = new PermissionViewRsDTOv1();
         try {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/permission/PermissionUpdateController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/permission/PermissionUpdateController.java
@@ -51,7 +51,7 @@ public class PermissionUpdateController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/permission/{permissionId}/v1")
     public ResponseEntity<?> permissionUpdateV1(
-            @MapperContextBinding(roots = PermissionRestDTOMapper.class, response = PermissionUpdateRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = PermissionRestDTOMapper.class, response = PermissionUpdateRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.PERMISSION_ID) @PathVariable UUID permissionId,
             @RequestBody PermissionUpdateRqDTOv1 request) {
         PermissionUpdateRsDTOv1 rs = new PermissionUpdateRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/permission/UserPermissionListController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/permission/UserPermissionListController.java
@@ -48,7 +48,7 @@ public class UserPermissionListController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/private/user/{userId}/permission/v1")
     public ResponseEntity<?> userPermissionListV1(
-            @MapperContextBinding(roots = PermissionRestDTOMapperV2.class, response = PermissionListRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = PermissionRestDTOMapperV2.class, response = PermissionListRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.USER_ID) @PathVariable UUID userId) {
         PermissionListRsDTOv1 rs = new PermissionListRsDTOv1();
         try {
@@ -72,7 +72,7 @@ public class UserPermissionListController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/private/user/permission/v1")
     public ResponseEntity<?> currentUserPermissionListV1(
-            @MapperContextBinding(roots = PermissionRestDTOMapperV2.class, response = PermissionListRsDTOv1.class) MapperContext mapperContext) {
+            @MapperContextBinding(roots = PermissionRestDTOMapperV2.class, response = PermissionListRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext) {
         PermissionListRsDTOv1 rs = new PermissionListRsDTOv1();
         try {
             rs.setPermissions(permissionRestDTOMapperV2.convertCollection(
@@ -95,7 +95,7 @@ public class UserPermissionListController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @RequestMapping(value = "/private/user/{userId}/permission_group/v1", method = RequestMethod.GET)
     public ResponseEntity<?> userPermissionGroupedListV1(
-            @MapperContextBinding(roots = PermissionGroupWithGroupRestDTOMapper.class, response = PermissionGroupedListRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = PermissionGroupWithGroupRestDTOMapper.class, response = PermissionGroupedListRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.USER_ID) @PathVariable UUID userId) {
         PermissionGroupedListRsDTOv1 rs = new PermissionGroupedListRsDTOv1();
         try {
@@ -119,7 +119,7 @@ public class UserPermissionListController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @RequestMapping(value = "/private/user/permission_group/v1", method = RequestMethod.GET)
     public ResponseEntity<?> currentUserPermissionGroupedListV1(
-            @MapperContextBinding(roots = PermissionGroupWithGroupRestDTOMapper.class, response = PermissionGroupedListRsDTOv1.class) MapperContext mapperContext) {
+            @MapperContextBinding(roots = PermissionGroupWithGroupRestDTOMapper.class, response = PermissionGroupedListRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext) {
         PermissionGroupedListRsDTOv1 rs = new PermissionGroupedListRsDTOv1();
         try {
             rs.permissionGroups = permissionGroupWithGroupRestDTOMapper.convertCollection(

--- a/core/src/main/java/org/twins/core/controller/rest/priv/space/SpaceRoleSearchController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/space/SpaceRoleSearchController.java
@@ -54,7 +54,7 @@ public class SpaceRoleSearchController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/space_role/search/v1")
     public ResponseEntity<?> spaceRoleSearchListV1(
-            @MapperContextBinding(roots = SpaceRoleDTOMapperV2.class, response = SpaceRoleSearchRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = SpaceRoleDTOMapperV2.class, response = SpaceRoleSearchRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @RequestBody SpaceRoleSearchRqDTOv1 request,
             @SimplePaginationParams SimplePagination pagination) {
         SpaceRoleSearchRsDTOv1 rs = new SpaceRoleSearchRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/space/SpaceRoleUserListController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/space/SpaceRoleUserListController.java
@@ -61,7 +61,7 @@ public class SpaceRoleUserListController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/private/space/{spaceId}/role/{roleId}/users/v1")
     public ResponseEntity<?> spaceRoleForUserListV1(
-            @MapperContextBinding(roots = UserRestDTOMapper.class, response = UserListRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = UserRestDTOMapper.class, response = UserListRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.SPACE_ID) @PathVariable UUID spaceId,
             @Parameter(example = DTOExamples.ROLE_ID) @PathVariable UUID roleId) {
         UserListRsDTOv1 rs = new UserListRsDTOv1();
@@ -84,7 +84,7 @@ public class SpaceRoleUserListController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/private/space/{spaceId}/users/list/v1")
     public ResponseEntity<?> spaceUserListV1(
-            @MapperContextBinding(roots = UserRefSpaceRoleDTOMapper.class, response = UserWithinSpaceRolesListRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = UserRefSpaceRoleDTOMapper.class, response = UserWithinSpaceRolesListRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.SPACE_ID) @PathVariable UUID spaceId,
             @SimplePaginationParams(sortAsc = false, sortField = TwinEntity.Fields.createdAt) SimplePagination pagination) {
         UserWithinSpaceRolesListRsDTOv1 rs = new UserWithinSpaceRolesListRsDTOv1();
@@ -111,7 +111,7 @@ public class SpaceRoleUserListController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/space/{spaceId}/users/search/v1")
     public ResponseEntity<?> spaceRoleUserSearchV1(
-            @MapperContextBinding(roots = UserRefSpaceRoleDTOMapper.class, response = UserWithinSpaceRolesListRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = UserRefSpaceRoleDTOMapper.class, response = UserWithinSpaceRolesListRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.SPACE_ID) @PathVariable UUID spaceId,
             @SimplePaginationParams(sortAsc = false, sortField = TwinEntity.Fields.createdAt) SimplePagination pagination,
             @RequestBody UserRefSpaceRoleSearchDTOv1 request) {
@@ -138,7 +138,7 @@ public class SpaceRoleUserListController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/private/space/{spaceId}/users/{userId}/v1")
     public ResponseEntity<?> spaceRoleUserViewV1(
-            @MapperContextBinding(roots = UserRefSpaceRoleDTOMapper.class, response = UserWithinSpaceRolesViewRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = UserRefSpaceRoleDTOMapper.class, response = UserWithinSpaceRolesViewRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.SPACE_ID) @PathVariable UUID spaceId,
             @Parameter(example = DTOExamples.PERMISSION_ID) @PathVariable("userId") UUID userId) {
         UserWithinSpaceRolesViewRsDTOv1 rs = new UserWithinSpaceRolesViewRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/space/SpaceRoleUserManageController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/space/SpaceRoleUserManageController.java
@@ -44,7 +44,7 @@ public class SpaceRoleUserManageController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/space/{spaceId}/role/{roleId}/users/manage/v1")
     public ResponseEntity<?> spaceRoleUserManageV1(
-            @MapperContextBinding(roots = UserRestDTOMapper.class, response = UserListRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = UserRestDTOMapper.class, response = UserListRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.TWIN_ID) @PathVariable UUID spaceId,
             @Parameter(example = DTOExamples.ROLE_ID) @PathVariable UUID roleId,
             @RequestBody SpaceRoleUserRqDTOv1 request) {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/space/SpaceRoleUserOverrideController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/space/SpaceRoleUserOverrideController.java
@@ -44,7 +44,7 @@ public class SpaceRoleUserOverrideController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/space/{spaceId}/role/{roleId}/users/override/v1")
     public ResponseEntity<?> spaceRoleUserOverrideV1(
-            @MapperContextBinding(roots = UserRestDTOMapper.class, response = UserListRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = UserRestDTOMapper.class, response = UserListRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.TWIN_ID) @PathVariable UUID spaceId,
             @Parameter(example = DTOExamples.ROLE_ID) @PathVariable UUID roleId,
             @RequestBody SpaceRoleUserOverrideRqDTOv1 request) {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/system/FeaturerSearchController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/system/FeaturerSearchController.java
@@ -52,7 +52,7 @@ public class FeaturerSearchController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/featurer/search/v1")
     public ResponseEntity<?> featurerSearchV1(
-            @MapperContextBinding(roots = FeaturerRestDTOMapper.class, response = FeaturerSearchRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = FeaturerRestDTOMapper.class, response = FeaturerSearchRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @SimplePaginationParams(sortField = FeaturerEntity.Fields.name) SimplePagination pagination,
             @RequestBody FeaturerSearchRqDTOv1 request) {
         FeaturerSearchRsDTOv1 rs = new FeaturerSearchRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/tier/TierCreateController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/tier/TierCreateController.java
@@ -47,7 +47,7 @@ public class TierCreateController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/tier/v1")
     public ResponseEntity<?> tierCreateV1(
-            @MapperContextBinding(roots = TierRestDTOMapperV2.class, response = TierSaveRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TierRestDTOMapperV2.class, response = TierSaveRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @RequestBody TierCreateRqDTOv1 request) {
         TierSaveRsDTOv1 rs = new TierSaveRsDTOv1();
         try {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/tier/TierSearchController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/tier/TierSearchController.java
@@ -57,7 +57,7 @@ public class TierSearchController extends ApiController {
     })
     @PostMapping(value = "/private/tier/search/v1")
     public ResponseEntity<?> tierSearchV1(
-            @MapperContextBinding(roots = TierRestDTOMapperV2.class, response = TierSearchRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TierRestDTOMapperV2.class, response = TierSearchRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @RequestBody TierSearchRqDTOv1 request,
             @SimplePaginationParams SimplePagination pagination) {
 

--- a/core/src/main/java/org/twins/core/controller/rest/priv/tier/TierUpdateController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/tier/TierUpdateController.java
@@ -50,7 +50,7 @@ public class TierUpdateController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PutMapping(value = "/private/tier/{tierId}/v1")
     public ResponseEntity<?> tierUpdateV1(
-            @MapperContextBinding(roots = TierRestDTOMapper.class, response = TierSaveRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TierRestDTOMapper.class, response = TierSaveRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.TIER_ID) @PathVariable UUID tierId,
             @RequestBody TierUpdateRqDTOv1 request) {
         TierSaveRsDTOv1 rs = new TierSaveRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/transition/TransitionAliasListController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/transition/TransitionAliasListController.java
@@ -52,7 +52,7 @@ public class TransitionAliasListController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/transition_alias/search/v1")
     public ResponseEntity<?> transitionAliasSearchV1(
-            @MapperContextBinding(roots = TransitionAliasRestDTOMapper.class, response = TransitionAliasSearchRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TransitionAliasRestDTOMapper.class, response = TransitionAliasSearchRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @SimplePaginationParams SimplePagination pagination,
             @RequestBody TransitionAliasSearchRqDTOv1 request) {
         TransitionAliasSearchRsDTOv1 rs = new TransitionAliasSearchRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/transition/TwinTransitionDraftController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/transition/TwinTransitionDraftController.java
@@ -65,7 +65,7 @@ public class TwinTransitionDraftController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/transition/{transitionId}/draft/v1")
     public ResponseEntity<?> twinTransitionDraftV1(
-            @MapperContextBinding(roots = DraftRestDTOMapper.class, response = TwinTransitionDraftRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = DraftRestDTOMapper.class, response = TwinTransitionDraftRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.TWINFLOW_TRANSITION_ID) @PathVariable UUID transitionId,
             @RequestBody TwinTransitionDraftRqDTOv1 request) {
         TwinTransitionDraftRsDTOv1 rs = new TwinTransitionDraftRsDTOv1();
@@ -99,7 +99,7 @@ public class TwinTransitionDraftController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/transition_by_alias/{transitionAlias}/draft/v1")
     public ResponseEntity<?> twinTransitionByAliasDraftV1(
-            @MapperContextBinding(roots = DraftRestDTOMapper.class, response = TwinTransitionDraftRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = DraftRestDTOMapper.class, response = TwinTransitionDraftRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.TWINFLOW_TRANSITION_ALIAS) @PathVariable String transitionAlias,
             @RequestBody TwinTransitionDraftRqDTOv1 request) {
         TwinTransitionDraftRsDTOv1 rs = new TwinTransitionDraftRsDTOv1();
@@ -133,7 +133,7 @@ public class TwinTransitionDraftController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @RequestMapping(value = "/private/transition/{transitionId}/draft/batch/v1", method = RequestMethod.POST)
     public ResponseEntity<?> twinTransitionDraftBatchV1(
-            @MapperContextBinding(roots = DraftRestDTOMapper.class, response = TwinTransitionDraftRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = DraftRestDTOMapper.class, response = TwinTransitionDraftRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.TWINFLOW_TRANSITION_ID) @PathVariable UUID transitionId,
             @RequestBody TwinTransitionDraftBatchRqDTOv1 request) {
         TwinTransitionDraftRsDTOv1 rs = new TwinTransitionDraftRsDTOv1();
@@ -172,7 +172,7 @@ public class TwinTransitionDraftController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @RequestMapping(value = "/private/transition_by_alias/{transitionAlias}/draft/batch/v1", method = RequestMethod.POST)
     public ResponseEntity<?> twinTransitionByAliasDraftBatchV1(
-            @MapperContextBinding(roots = DraftRestDTOMapper.class, response = TwinTransitionDraftRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = DraftRestDTOMapper.class, response = TwinTransitionDraftRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.TWINFLOW_TRANSITION_ALIAS) @PathVariable String transitionAlias,
             @RequestBody TwinTransitionDraftBatchRqDTOv1 request) {
         TwinTransitionDraftRsDTOv1 rs = new TwinTransitionDraftRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/transition/TwinTransitionPerformController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/transition/TwinTransitionPerformController.java
@@ -67,7 +67,7 @@ public class TwinTransitionPerformController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/transition/{transitionId}/perform/v2")
     public ResponseEntity<?> twinTransitionPerformV2(
-            @MapperContextBinding(roots = TwinTransitionPerformRsRestDTOMapperV2.class, response = TwinTransitionPerformRsDTOv2.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TwinTransitionPerformRsRestDTOMapperV2.class, response = TwinTransitionPerformRsDTOv2.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.TWINFLOW_TRANSITION_ID) @PathVariable UUID transitionId,
             @RequestBody TwinTransitionPerformRqDTOv1 request) {
         TwinTransitionPerformRsDTOv2 rs = new TwinTransitionPerformRsDTOv2();
@@ -97,7 +97,7 @@ public class TwinTransitionPerformController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/transition_by_alias/{transitionAlias}/perform/v2")
     public ResponseEntity<?> twinTransitionByAliasPerformV2(
-            @MapperContextBinding(roots = TwinTransitionPerformRsRestDTOMapperV2.class, response = TwinTransitionPerformRsDTOv2.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TwinTransitionPerformRsRestDTOMapperV2.class, response = TwinTransitionPerformRsDTOv2.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.TWINFLOW_TRANSITION_ALIAS) @PathVariable String transitionAlias,
             @RequestBody TwinTransitionPerformRqDTOv1 request) {
         TwinTransitionPerformRsDTOv2 rs = new TwinTransitionPerformRsDTOv2();
@@ -126,7 +126,7 @@ public class TwinTransitionPerformController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @RequestMapping(value = "/private/transition/{transitionId}/perform/batch/v2", method = RequestMethod.POST)
     public ResponseEntity<?> twinTransitionPerformBatchV2(
-            @MapperContextBinding(roots = TwinTransitionPerformRsRestDTOMapperV2.class, response = TwinTransitionPerformRsDTOv2.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TwinTransitionPerformRsRestDTOMapperV2.class, response = TwinTransitionPerformRsDTOv2.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.TWINFLOW_TRANSITION_ID) @PathVariable UUID transitionId,
             @RequestBody TwinTransitionPerformBatchRqDTOv1 request) {
         TwinTransitionPerformRsDTOv2 rs = new TwinTransitionPerformRsDTOv2();
@@ -160,7 +160,7 @@ public class TwinTransitionPerformController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @RequestMapping(value = "/private/transition_by_alias/{transitionAlias}/perform/batch/v2", method = RequestMethod.POST)
     public ResponseEntity<?> twinTransitionByAliasPerformBatchV2(
-            @MapperContextBinding(roots = TwinTransitionPerformRsRestDTOMapperV2.class, response = TwinTransitionPerformRsDTOv2.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TwinTransitionPerformRsRestDTOMapperV2.class, response = TwinTransitionPerformRsDTOv2.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.TWINFLOW_TRANSITION_ALIAS) @PathVariable String transitionAlias,
             @RequestBody TwinTransitionPerformBatchRqDTOv1 request) {
         TwinTransitionPerformRsDTOv2 rs = new TwinTransitionPerformRsDTOv2();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/transition/TwinTransitionPerformControllerOld.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/transition/TwinTransitionPerformControllerOld.java
@@ -68,7 +68,7 @@ public class TwinTransitionPerformControllerOld extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/transition/{transitionId}/perform/v1")
     public ResponseEntity<?> twinTransitionPerformV1(
-            @MapperContextBinding(roots = TwinTransitionPerformRsRestDTOMapperV1.class, response = TwinTransitionPerformRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TwinTransitionPerformRsRestDTOMapperV1.class, response = TwinTransitionPerformRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.TWINFLOW_TRANSITION_ID) @PathVariable UUID transitionId,
             @RequestBody TwinTransitionPerformRqDTOv1 request) {
         TwinTransitionPerformRsDTOv1 rs = new TwinTransitionPerformRsDTOv1();
@@ -99,7 +99,7 @@ public class TwinTransitionPerformControllerOld extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/transition_by_alias/{transitionAlias}/perform/v1")
     public ResponseEntity<?> twinTransitionByAliasPerformV1(
-            @MapperContextBinding(roots = TwinTransitionPerformRsRestDTOMapperV1.class, response = TwinTransitionPerformRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TwinTransitionPerformRsRestDTOMapperV1.class, response = TwinTransitionPerformRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.TWINFLOW_TRANSITION_ALIAS) @PathVariable String transitionAlias,
             @RequestBody TwinTransitionPerformRqDTOv1 request) {
         TwinTransitionPerformRsDTOv1 rs = new TwinTransitionPerformRsDTOv1();
@@ -129,7 +129,7 @@ public class TwinTransitionPerformControllerOld extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @RequestMapping(value = "/private/transition/{transitionId}/perform/batch/v1", method = RequestMethod.POST)
     public ResponseEntity<?> twinTransitionPerformBatchV1(
-            @MapperContextBinding(roots = TwinTransitionPerformRsRestDTOMapperV1.class, response = TwinTransitionPerformRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TwinTransitionPerformRsRestDTOMapperV1.class, response = TwinTransitionPerformRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.TWINFLOW_TRANSITION_ID) @PathVariable UUID transitionId,
             @RequestBody TwinTransitionPerformBatchRqDTOv1 request) {
         TwinTransitionPerformRsDTOv1 rs = new TwinTransitionPerformRsDTOv1();
@@ -164,7 +164,7 @@ public class TwinTransitionPerformControllerOld extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @RequestMapping(value = "/private/transition_by_alias/{transitionAlias}/perform/batch/v1", method = RequestMethod.POST)
     public ResponseEntity<?> twinTransitionByAliasPerformBatchV1(
-            @MapperContextBinding(roots = TwinTransitionPerformRsRestDTOMapperV1.class, response = TwinTransitionPerformRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TwinTransitionPerformRsRestDTOMapperV1.class, response = TwinTransitionPerformRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.TWINFLOW_TRANSITION_ALIAS) @PathVariable String transitionAlias,
             @RequestBody TwinTransitionPerformBatchRqDTOv1 request) {
         TwinTransitionPerformRsDTOv1 rs = new TwinTransitionPerformRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/twin/TwinDeleteController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/twin/TwinDeleteController.java
@@ -47,7 +47,7 @@ public class TwinDeleteController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @DeleteMapping(value = "/private/twin/{twinId}/v1")
     public ResponseEntity<?> twinDeleteV1(
-            @MapperContextBinding(roots = DraftRestDTOMapper.class, response = DraftRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = DraftRestDTOMapper.class, response = DraftRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.TWIN_ID) @PathVariable UUID twinId) {
         DraftRsDTOv1 rs = new DraftRsDTOv1();
         try {
@@ -70,7 +70,7 @@ public class TwinDeleteController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/twin/delete/v1")
     public ResponseEntity<?> twinDeleteBatchV1(
-            @MapperContextBinding(roots = DraftRestDTOMapper.class, response = DraftRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = DraftRestDTOMapper.class, response = DraftRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @RequestBody TwinDeleteRqDTOv1 twinDeleteRqDTOv1) {
         DraftRsDTOv1 rs = new DraftRsDTOv1();
         try {
@@ -93,7 +93,7 @@ public class TwinDeleteController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @DeleteMapping(value = "/private/twin/{twinId}/delete_drafted/v1")
     public ResponseEntity<?> twinDeleteDraftedV1(
-            @MapperContextBinding(roots = DraftRestDTOMapper.class, response = DraftRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = DraftRestDTOMapper.class, response = DraftRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.TWIN_ID) @PathVariable UUID twinId) {
         DraftRsDTOv1 rs = new DraftRsDTOv1();
         try {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/twin/TwinFieldSaveController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/twin/TwinFieldSaveController.java
@@ -115,7 +115,7 @@ public class TwinFieldSaveController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/twin/{twinId}/field_list/v1")
     public ResponseEntity<?> twinFieldListUpdateV1(
-            @MapperContextBinding(roots = TwinRestDTOMapperV2.class, response = TwinRsDTOv2.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TwinRestDTOMapperV2.class, response = TwinRsDTOv2.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(name = "twinId", in = ParameterIn.PATH, required = true, example = DTOExamples.TWIN_ID) @PathVariable UUID twinId,
             @RequestBody TwinFieldListUpdateRqDTOv1 request) {
         TwinRsDTOv2 rs = new TwinRsDTOv2();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/twin/TwinFieldViewController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/twin/TwinFieldViewController.java
@@ -48,7 +48,7 @@ public class TwinFieldViewController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/private/twin/{twinId}/field/{fieldKey}/v1")
     public ResponseEntity<?> twinFieldByKeyViewV1(
-            @MapperContextBinding(roots = TwinFieldRestDTOMapper.class, response = TwinFieldRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TwinFieldRestDTOMapper.class, response = TwinFieldRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.TWIN_ID) @PathVariable UUID twinId,
             @Parameter(example = DTOExamples.TWIN_FIELD_KEY) @PathVariable String fieldKey) {
         TwinFieldRsDTOv1 rs = new TwinFieldRsDTOv1();
@@ -63,7 +63,7 @@ public class TwinFieldViewController extends ApiController {
         return new ResponseEntity<>(rs, HttpStatus.OK);
     }
 
-    private void fillResponse(TwinField twinField, MapperContext mapperContext, TwinFieldRsDTOv1 rs) throws Exception {
+    private void fillResponse(TwinField twinField, @Schema(hidden = true) MapperContext mapperContext, TwinFieldRsDTOv1 rs) throws Exception {
         rs
                 .twinId(twinField.getTwinId())
                 .field(twinFieldRestDTOMapper.convert(

--- a/core/src/main/java/org/twins/core/controller/rest/priv/twin/TwinListController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/twin/TwinListController.java
@@ -62,7 +62,7 @@ public class TwinListController extends ApiController {
     @PostMapping(value = "/private/twin/search/v1")
     @Loggable(rsBodyThreshold = 2000)
     public ResponseEntity<?> twinSearchV1(
-            @MapperContextBinding(roots = TwinRestDTOMapper.class, response = TwinSearchRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TwinRestDTOMapper.class, response = TwinSearchRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @SimplePaginationParams(sortAsc = false, sortField = TwinEntity.Fields.createdAt) SimplePagination pagination,
             @RequestBody TwinSearchRqDTOv1 request) {
         TwinSearchRsDTOv1 rs = new TwinSearchRsDTOv1();
@@ -90,7 +90,7 @@ public class TwinListController extends ApiController {
     @PostMapping(value = "/private/twin/search/v2")
     @Loggable(rsBodyThreshold = 2000)
     public ResponseEntity<?> twinSearchV2(
-            @MapperContextBinding(roots = TwinRestDTOMapperV2.class, response = TwinSearchRsDTOv2.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TwinRestDTOMapperV2.class, response = TwinSearchRsDTOv2.class) @Schema(hidden = true) MapperContext mapperContext,
             @SimplePaginationParams(sortAsc = false, sortField = TwinEntity.Fields.createdAt) SimplePagination pagination,
             @RequestBody TwinSearchRqDTOv1 request) {
         TwinSearchRsDTOv2 rs = new TwinSearchRsDTOv2();
@@ -118,7 +118,7 @@ public class TwinListController extends ApiController {
     @PostMapping(value = "/private/twin/search/v3")
     @Loggable(rsBodyThreshold = 2000)
     public ResponseEntity<?> twinSearchV3(
-            @MapperContextBinding(roots = TwinRestDTOMapperV2.class, response = TwinSearchRsDTOv2.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TwinRestDTOMapperV2.class, response = TwinSearchRsDTOv2.class) @Schema(hidden = true) MapperContext mapperContext,
             @SimplePaginationParams(sortAsc = false, sortField = TwinEntity.Fields.createdAt) SimplePagination pagination,
             @RequestBody List<TwinSearchRqDTOv1> request) {
         TwinSearchRsDTOv2 rs = new TwinSearchRsDTOv2();
@@ -150,7 +150,7 @@ public class TwinListController extends ApiController {
     @PostMapping(value = "/private/twin/search_by_alias/{searchAlias}/v1")
     @Loggable(rsBodyThreshold = 2000)
     public ResponseEntity<?> twinSearchByAliasV1(
-            @MapperContextBinding(roots = TwinRestDTOMapperV2.class, response = TwinSearchRsDTOv2.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TwinRestDTOMapperV2.class, response = TwinSearchRsDTOv2.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.SEARCH_ALIAS) @PathVariable String searchAlias,
             @SimplePaginationParams(sortAsc = false, sortField = TwinEntity.Fields.createdAt) SimplePagination pagination,
             @RequestBody TwinSearchByAliasRqDTOv1 request) {
@@ -179,7 +179,7 @@ public class TwinListController extends ApiController {
     @PostMapping(value = "/private/twin/search/{searchId}/v1")
     @Loggable(rsBodyThreshold = 2000)
     public ResponseEntity<?> twinSearchByIdV1(
-            @MapperContextBinding(roots = TwinRestDTOMapperV2.class, response = TwinSearchRsDTOv2.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TwinRestDTOMapperV2.class, response = TwinSearchRsDTOv2.class) @Schema(hidden = true) MapperContext mapperContext,
             @SimplePaginationParams(sortAsc = false, sortField = TwinEntity.Fields.createdAt) SimplePagination pagination,
             @Parameter(example = DTOExamples.SEARCH_ID) @PathVariable UUID searchId,
             @RequestBody TwinSearchByAliasRqDTOv1 request) {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/twin/TwinPermissionCheckOverviewController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/twin/TwinPermissionCheckOverviewController.java
@@ -50,7 +50,7 @@ public class TwinPermissionCheckOverviewController extends ApiController {
     @PostMapping(value = "/private/twin/{twinId}/permisson_check_overview/v1")
     @Loggable(rsBodyThreshold = 2000)
     public ResponseEntity<?> permissonCheckOverview(
-            @MapperContextBinding(roots = PermissionCheckOverviewDTOMapper.class, response = PermissionCheckOverviewRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = PermissionCheckOverviewDTOMapper.class, response = PermissionCheckOverviewRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.TWIN_ID) @PathVariable UUID twinId,
             @RequestBody PermissionCheckOverviewRqDTOv1 request) {
         PermissionCheckOverviewRsDTOv1 rs = new PermissionCheckOverviewRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/twin/TwinUpdateController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/twin/TwinUpdateController.java
@@ -54,7 +54,7 @@ public class TwinUpdateController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PutMapping(value = "/private/twin/{twinId}/v1")
     public ResponseEntity<?> twinUpdateV1(
-            @MapperContextBinding(roots = TwinRestDTOMapperV2.class, response = TwinRsDTOv2.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TwinRestDTOMapperV2.class, response = TwinRsDTOv2.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.TWIN_ID) @PathVariable UUID twinId,
             @RequestBody TwinUpdateRqDTOv1 request) {
         TwinRsDTOv2 rs = new TwinRsDTOv2();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/twin/TwinValidHeadController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/twin/TwinValidHeadController.java
@@ -54,7 +54,7 @@ public class TwinValidHeadController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/twin/{twinId}/valid_heads/v1")
     public ResponseEntity<?> validLinkedTwinsV1(
-            @MapperContextBinding(roots = TwinRestDTOMapperV2.class, response = TwinSearchRsDTOv2.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TwinRestDTOMapperV2.class, response = TwinSearchRsDTOv2.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.TWIN_CLASS_ID) @PathVariable UUID twinId,
             @RequestBody TwinSearchSimpleDTOv1 search,
             @SimplePaginationParams SimplePagination pagination) {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/twin/TwinValidLinkedTwinController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/twin/TwinValidLinkedTwinController.java
@@ -54,7 +54,7 @@ public class TwinValidLinkedTwinController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/twin/{twinId}/link/{linkId}/valid_twins/v1")
     public ResponseEntity<?> validLinkedTwinsV1(
-            @MapperContextBinding(roots = TwinRestDTOMapperV2.class, response = TwinSearchRsDTOv2.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TwinRestDTOMapperV2.class, response = TwinSearchRsDTOv2.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.TWIN_ID) @PathVariable UUID twinId,
             @Parameter(example = DTOExamples.LINK_ID) @PathVariable UUID linkId,
             @RequestBody TwinSearchSimpleDTOv1 search,

--- a/core/src/main/java/org/twins/core/controller/rest/priv/twin/TwinViewController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/twin/TwinViewController.java
@@ -54,7 +54,7 @@ public class TwinViewController extends ApiController {
     @GetMapping(value = "/private/twin/{twinId}/v1")
 
     public ResponseEntity<?> twinViewV1(
-            @MapperContextBinding(roots = TwinRestDTOMapper.class, response = TwinRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TwinRestDTOMapper.class, response = TwinRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.TWIN_ID) @PathVariable UUID twinId) {
         TwinRsDTOv1 rs = new TwinRsDTOv1();
         try {
@@ -78,7 +78,7 @@ public class TwinViewController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/private/twin/{twinId}/v2")
     public ResponseEntity<?> twinViewV2(
-            @MapperContextBinding(roots = TwinRestDTOMapperV2.class, response = TwinRsDTOv2.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TwinRestDTOMapperV2.class, response = TwinRsDTOv2.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.TWIN_ID) @PathVariable UUID twinId) {
         TwinRsDTOv2 rs = new TwinRsDTOv2();
         try {
@@ -102,7 +102,7 @@ public class TwinViewController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/private/twin_by_alias/{twinAlias}/v1")
     public ResponseEntity<?> twinViewByAliasV1(
-            @MapperContextBinding(roots = TwinRestDTOMapper.class, response = TwinRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TwinRestDTOMapper.class, response = TwinRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.TWIN_ID) @PathVariable String twinAlias) {
         TwinRsDTOv1 rs = new TwinRsDTOv1();
         try {
@@ -126,7 +126,7 @@ public class TwinViewController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/private/twin_by_alias/{twinAlias}/v2")
     public ResponseEntity<?> twinViewByAliasV2(
-            @MapperContextBinding(roots = TwinRestDTOMapper.class, response = TwinRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TwinRestDTOMapper.class, response = TwinRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.TWIN_ID) @PathVariable String twinAlias) {
         TwinRsDTOv1 rs = new TwinRsDTOv1();
         try {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/twinclass/TwinClassCreateController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/twinclass/TwinClassCreateController.java
@@ -19,9 +19,11 @@ import org.twins.core.controller.rest.ApiTag;
 import org.twins.core.controller.rest.annotation.MapperContextBinding;
 import org.twins.core.controller.rest.annotation.ParametersApiUserHeaders;
 import org.twins.core.controller.rest.annotation.ProtectedBy;
-import org.twins.core.dao.i18n.I18nEntity;
 import org.twins.core.dao.twinclass.TwinClassEntity;
-import org.twins.core.dto.rest.twinclass.*;
+import org.twins.core.dto.rest.twinclass.TwinClassCreateRqDTOv1;
+import org.twins.core.dto.rest.twinclass.TwinClassCreateRqDTOv2;
+import org.twins.core.dto.rest.twinclass.TwinClassCreateRsDTOv1;
+import org.twins.core.dto.rest.twinclass.TwinClassCreateRsDTOv2;
 import org.twins.core.mappers.rest.mappercontext.MapperContext;
 import org.twins.core.mappers.rest.related.RelatedObjectsRestDTOConverter;
 import org.twins.core.mappers.rest.twinclass.TwinClassCreateRestDTOReverseMapper;
@@ -54,7 +56,7 @@ public class TwinClassCreateController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/twin_class/v1")
     public ResponseEntity<?> twinClassCreateV1(
-            @MapperContextBinding(roots = TwinClassRestDTOMapper.class, response = TwinClassCreateRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TwinClassRestDTOMapper.class, response = TwinClassCreateRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @RequestBody TwinClassCreateRqDTOv1 request) {
         TwinClassCreateRsDTOv1 rs = new TwinClassCreateRsDTOv1();
         try {
@@ -79,7 +81,7 @@ public class TwinClassCreateController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/twin_class/v2")
     public ResponseEntity<?> twinClassCreateV2(
-            @MapperContextBinding(roots = TwinClassRestDTOMapper.class, response = TwinClassCreateRsDTOv2.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TwinClassRestDTOMapper.class, response = TwinClassCreateRsDTOv2.class) @Schema(hidden = true) MapperContext mapperContext,
             @RequestBody TwinClassCreateRqDTOv2 request) {
         TwinClassCreateRsDTOv2 rs = new TwinClassCreateRsDTOv2();
         try {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/twinclass/TwinClassDuplicateController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/twinclass/TwinClassDuplicateController.java
@@ -48,7 +48,7 @@ public class TwinClassDuplicateController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/twin_class/{twinClassId}/duplicate/v1")
     public ResponseEntity<?> twinClassDuplicateV1(
-            @MapperContextBinding(roots = TwinClassRestDTOMapper.class, response = TwinClassRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TwinClassRestDTOMapper.class, response = TwinClassRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.TWIN_CLASS_ID) @PathVariable UUID twinClassId,
             @RequestBody TwinClassDuplicateRqDTOv1 request) {
         TwinClassRsDTOv1 rs = new TwinClassRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/twinclass/TwinClassFieldCreateController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/twinclass/TwinClassFieldCreateController.java
@@ -55,7 +55,7 @@ public class TwinClassFieldCreateController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/twin_class/{twinClassId}/field/v1")
     public ResponseEntity<?> twinClassFieldCreateV1(
-            @MapperContextBinding(roots = TwinClassFieldRestDTOMapperV2.class, response = TwinClassFieldRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TwinClassFieldRestDTOMapperV2.class, response = TwinClassFieldRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.TWIN_CLASS_ID) @PathVariable UUID twinClassId,
             @RequestBody TwinClassFieldCreateRqDTOv1 request) {
         TwinClassFieldRsDTOv1 rs = new TwinClassFieldRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/twinclass/TwinClassFieldListController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/twinclass/TwinClassFieldListController.java
@@ -55,7 +55,7 @@ public class TwinClassFieldListController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/private/twin_class/{twinClassId}/field/list/v1")
     public ResponseEntity<?> twinClassFieldListV1(
-            @MapperContextBinding(roots = TwinClassFieldRestDTOMapperV2.class, response = TwinClassFieldListRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TwinClassFieldRestDTOMapperV2.class, response = TwinClassFieldListRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.TWIN_CLASS_ID) @PathVariable UUID twinClassId) {
         TwinClassFieldListRsDTOv1 rs = new TwinClassFieldListRsDTOv1();
         try {
@@ -81,7 +81,7 @@ public class TwinClassFieldListController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/private/twin_class_field/{twinClassFieldId}/v1")
     public ResponseEntity<?> twinClassFieldViewV1(
-            @MapperContextBinding(roots = TwinClassFieldRestDTOMapperV2.class, response = TwinClassFieldRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TwinClassFieldRestDTOMapperV2.class, response = TwinClassFieldRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.TWIN_CLASS_FIELD_ID) @PathVariable UUID twinClassFieldId) {
         TwinClassFieldRsDTOv1 rs = new TwinClassFieldRsDTOv1();
         try {
@@ -106,7 +106,7 @@ public class TwinClassFieldListController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/private/twin_class_by_key/{classKey}/field/{fieldKey}/v1")
     public ResponseEntity<?> twinClassFieldViewByKeyV1(
-            @MapperContextBinding(roots = TwinClassFieldRestDTOMapper.class, response = TwinClassFieldRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TwinClassFieldRestDTOMapper.class, response = TwinClassFieldRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.TWIN_CLASS_KEY) @PathVariable String classKey,
             @Parameter(example = DTOExamples.TWIN_FIELD_KEY) @PathVariable String fieldKey) {
         TwinClassFieldRsDTOv1 rs = new TwinClassFieldRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/twinclass/TwinClassFieldSearchController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/twinclass/TwinClassFieldSearchController.java
@@ -54,7 +54,7 @@ public class TwinClassFieldSearchController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/twin_class_fields/search/v1")
     public ResponseEntity<?> twinClassFieldSearchV1(
-            @MapperContextBinding(roots = TwinClassFieldRestDTOMapperV2.class, response = TwinClassFieldSearchRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TwinClassFieldRestDTOMapperV2.class, response = TwinClassFieldSearchRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @SimplePaginationParams SimplePagination pagination,
             @RequestBody TwinClassFieldSearchRqDTOv1 request) {
         TwinClassFieldSearchRsDTOv1 rs = new TwinClassFieldSearchRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/twinclass/TwinClassFieldSharedController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/twinclass/TwinClassFieldSharedController.java
@@ -48,7 +48,7 @@ public class TwinClassFieldSharedController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/private/twin_class_field/{twinClassFieldId}/data_list_shared_in_head/{headTwinId}/v1")
     public ResponseEntity<?> twinClassFieldDataListSharedInHeadV1(
-            @MapperContextBinding(roots = DataListRestDTOMapper.class, response = DataListRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = DataListRestDTOMapper.class, response = DataListRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.TWIN_CLASS_FIELD_SHARED_IN_HEAD_ID) @PathVariable UUID twinClassFieldId,
             @Parameter(example = DTOExamples.HEAD_TWIN_ID) @PathVariable UUID headTwinId) {
         DataListRsDTOv1 rs = new DataListRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/twinclass/TwinClassFieldUpdateController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/twinclass/TwinClassFieldUpdateController.java
@@ -57,7 +57,7 @@ public class TwinClassFieldUpdateController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PutMapping(value = "/private/twin_class_field/{twinClassFieldId}/v1")
     public ResponseEntity<?> twinClassFieldUpdateV1(
-            @MapperContextBinding(roots = TwinClassFieldRestDTOMapperV2.class, response = TwinClassFieldRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TwinClassFieldRestDTOMapperV2.class, response = TwinClassFieldRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.TWIN_CLASS_FIELD_ID) @PathVariable UUID twinClassFieldId,
             @RequestBody TwinClassFieldUpdateRqDTOv1 request) {
         TwinClassFieldRsDTOv1 rs = new TwinClassFieldRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/twinclass/TwinClassListController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/twinclass/TwinClassListController.java
@@ -53,7 +53,7 @@ public class TwinClassListController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/twin_class/search/v1")
     public ResponseEntity<?> twinClassSearchV1(
-            @MapperContextBinding(roots = TwinClassRestDTOMapper.class, response = TwinClassSearchRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TwinClassRestDTOMapper.class, response = TwinClassSearchRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @SimplePaginationParams(sortField = TwinClassEntity.Fields.key) SimplePagination pagination,
             @RequestBody TwinClassSearchRqDTOv1 request) {
         TwinClassSearchRsDTOv1 rs = new TwinClassSearchRsDTOv1();
@@ -81,7 +81,7 @@ public class TwinClassListController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/private/twin_class/list/v1")
     public ResponseEntity<?> twinClassLstV1(
-            @MapperContextBinding(roots = TwinClassRestDTOMapper.class, response = TwinClassSearchRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TwinClassRestDTOMapper.class, response = TwinClassSearchRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @SimplePaginationParams SimplePagination pagination) {
         TwinClassSearchRsDTOv1 rs = new TwinClassSearchRsDTOv1();
         try {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/twinclass/TwinClassTagSearchController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/twinclass/TwinClassTagSearchController.java
@@ -67,7 +67,7 @@ public class TwinClassTagSearchController extends ApiController {
     @PostMapping(value = "/private/twin_class/{twinClassId}/tag/search/v1")
     public ResponseEntity<?> tagSearchV1(
             @MapperContextBinding(roots = DataListRestDTOMapperV2.class, response = TagSearchRsDTOv1.class)
-            MapperContext mapperContext,
+            @Schema(hidden = true) MapperContext mapperContext,
             @SimplePaginationParams SimplePagination pagination,
             @Parameter(example = DTOExamples.TWIN_CLASS_ID) @PathVariable UUID twinClassId,
             @RequestBody TagSearchRqDTOv1 request) {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/twinclass/TwinClassUpdateController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/twinclass/TwinClassUpdateController.java
@@ -16,12 +16,14 @@ import org.twins.core.controller.rest.ApiController;
 import org.twins.core.controller.rest.ApiTag;
 import org.twins.core.controller.rest.annotation.MapperContextBinding;
 import org.twins.core.controller.rest.annotation.ParametersApiUserHeaders;
-import org.twins.core.dao.twinclass.TwinClassEntity;
 import org.twins.core.controller.rest.annotation.ProtectedBy;
+import org.twins.core.dao.twinclass.TwinClassEntity;
 import org.twins.core.domain.twinclass.TwinClassUpdate;
 import org.twins.core.dto.rest.DTOExamples;
 import org.twins.core.dto.rest.Response;
-import org.twins.core.dto.rest.twinclass.*;
+import org.twins.core.dto.rest.twinclass.TwinClassRsDTOv1;
+import org.twins.core.dto.rest.twinclass.TwinClassUpdateRqDTOv1;
+import org.twins.core.dto.rest.twinclass.TwinClassUpdateRqDTOv2;
 import org.twins.core.mappers.rest.mappercontext.MapperContext;
 import org.twins.core.mappers.rest.related.RelatedObjectsRestDTOConverter;
 import org.twins.core.mappers.rest.twinclass.TwinClassRestDTOMapper;
@@ -55,7 +57,7 @@ public class TwinClassUpdateController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PutMapping(value = "/private/twin_class/{twinClassId}/v1")
     public ResponseEntity<?> twinClassUpdateV1(
-            @MapperContextBinding(roots = TwinClassRestDTOMapper.class, response = TwinClassRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TwinClassRestDTOMapper.class, response = TwinClassRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.TWIN_CLASS_ID) @PathVariable UUID twinClassId,
             @RequestBody TwinClassUpdateRqDTOv1 request) {
         TwinClassRsDTOv1 rs = new TwinClassRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/twinclass/TwinClassValidHeadController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/twinclass/TwinClassValidHeadController.java
@@ -54,7 +54,7 @@ public class TwinClassValidHeadController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/twin_class/{twinClassId}/valid_heads/v1")
     public ResponseEntity<?> validHeadV1(
-            @MapperContextBinding(roots = TwinRestDTOMapperV2.class, response = TwinSearchRsDTOv2.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TwinRestDTOMapperV2.class, response = TwinSearchRsDTOv2.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.TWIN_CLASS_ID) @PathVariable UUID twinClassId,
             @RequestBody TwinSearchSimpleDTOv1 search,
             @SimplePaginationParams SimplePagination pagination) {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/twinclass/TwinClassValidLinkedTwinController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/twinclass/TwinClassValidLinkedTwinController.java
@@ -54,7 +54,7 @@ public class TwinClassValidLinkedTwinController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/twin_class/{twinClassId}/link/{linkId}/valid_twins/v1")
     public ResponseEntity<?> validLinkedTwinV1(
-            @MapperContextBinding(roots = TwinRestDTOMapperV2.class, response = TwinSearchRsDTOv2.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TwinRestDTOMapperV2.class, response = TwinSearchRsDTOv2.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.TWIN_CLASS_ID) @PathVariable UUID twinClassId,
             @Parameter(example = DTOExamples.LINK_ID) @PathVariable UUID linkId,
             @RequestParam(required = false) UUID headTwinId,

--- a/core/src/main/java/org/twins/core/controller/rest/priv/twinclass/TwinClassViewController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/twinclass/TwinClassViewController.java
@@ -53,7 +53,7 @@ public class TwinClassViewController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/private/twin_class/{twinClassId}/v1")
     public ResponseEntity<?> twinClassViewV1(
-            @MapperContextBinding(roots = TwinClassRestDTOMapper.class, response = TwinClassRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TwinClassRestDTOMapper.class, response = TwinClassRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.TWIN_CLASS_ID) @PathVariable UUID twinClassId) {
         TwinClassRsDTOv1 rs = new TwinClassRsDTOv1();
         try {
@@ -78,7 +78,7 @@ public class TwinClassViewController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/private/twin_class_by_key/{twinClassKey}/v1")
     public ResponseEntity<?> twinClassViewByKeyV1(
-            @MapperContextBinding(roots = TwinClassRestDTOMapper.class, response = TwinClassRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TwinClassRestDTOMapper.class, response = TwinClassRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.TWIN_CLASS_KEY) @PathVariable String twinClassKey) {
         TwinClassRsDTOv1 rs = new TwinClassRsDTOv1();
         try {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/twinflow/TransitionCreateController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/twinflow/TransitionCreateController.java
@@ -51,7 +51,7 @@ public class TransitionCreateController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/twinflow/{twinflowId}/transition/v1")
     public ResponseEntity<?> transitionCreateV1(
-            @MapperContextBinding(roots = TransitionBaseV2RestDTOMapper.class, response = TransitionCreateRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TransitionBaseV2RestDTOMapper.class, response = TransitionCreateRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.TWINFLOW_ID) @PathVariable UUID twinflowId,
             @RequestBody TransitionCreateRqDTOv1 request) {
         TransitionCreateRsDTOv1 rs = new TransitionCreateRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/twinflow/TransitionListController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/twinflow/TransitionListController.java
@@ -12,7 +12,10 @@ import org.cambium.common.pagination.PaginationResult;
 import org.cambium.common.pagination.SimplePagination;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
 import org.twins.core.controller.rest.ApiController;
 import org.twins.core.controller.rest.ApiTag;
 import org.twins.core.controller.rest.annotation.MapperContextBinding;
@@ -51,7 +54,7 @@ public class TransitionListController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/transition/search/v1")
     public ResponseEntity<?> transitionSearchV1(
-            @MapperContextBinding(roots = TransitionBaseV2RestDTOMapper.class, response = TransitionSearchRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TransitionBaseV2RestDTOMapper.class, response = TransitionSearchRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @SimplePaginationParams SimplePagination pagination,
             @RequestBody TransitionSearchRqDTOv1 request) {
         TransitionSearchRsDTOv1 rs = new TransitionSearchRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/twinflow/TransitionUpdateController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/twinflow/TransitionUpdateController.java
@@ -61,7 +61,7 @@ public class TransitionUpdateController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/transition/{transitionId}/v1")
     public ResponseEntity<?> transitionUpdateV1(
-            @MapperContextBinding(roots = TransitionBaseV2RestDTOMapper.class, response = TransitionUpdateRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TransitionBaseV2RestDTOMapper.class, response = TransitionUpdateRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.TWINFLOW_TRANSITION_ID) @PathVariable UUID transitionId,
             @RequestBody TransitionUpdateRqDTOv1 request) {
         TransitionUpdateRsDTOv1 rs = new TransitionUpdateRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/twinflow/TransitionViewController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/twinflow/TransitionViewController.java
@@ -49,7 +49,7 @@ public class TransitionViewController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/private/transition/{transitionId}/v1")
     public ResponseEntity<?> transitionViewV1(
-            @MapperContextBinding(roots = TransitionBaseV3RestDTOMapper.class, response = TransitionViewRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TransitionBaseV3RestDTOMapper.class, response = TransitionViewRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.TWINFLOW_TRANSITION_ID) @PathVariable UUID transitionId) {
         TransitionViewRsDTOv1 rs = new TransitionViewRsDTOv1();
         try {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/twinflow/TwinflowCreateController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/twinflow/TwinflowCreateController.java
@@ -55,7 +55,7 @@ public class TwinflowCreateController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/twin_class/{twinClassId}/twinflow/v1")
     public ResponseEntity<?> twinflowCreateV1(
-            @MapperContextBinding(roots = TwinflowBaseV2RestDTOMapper.class, response = TwinflowCreateRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TwinflowBaseV2RestDTOMapper.class, response = TwinflowCreateRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.TWIN_CLASS_ID) @PathVariable UUID twinClassId,
             @RequestBody TwinflowCreateRqDTOv1 request) {
         TwinflowCreateRsDTOv1 rs = new TwinflowCreateRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/twinflow/TwinflowListController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/twinflow/TwinflowListController.java
@@ -54,7 +54,7 @@ public class TwinflowListController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/twinflow/search/v1")
     public ResponseEntity<?> twinflowSearchV1(
-            @MapperContextBinding(roots = TwinflowBaseV3RestDTOMapper.class, response = TwinflowSearchRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TwinflowBaseV3RestDTOMapper.class, response = TwinflowSearchRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @SimplePaginationParams SimplePagination pagination,
             @RequestBody TwinflowSearchRqDTOv1 request) {
         TwinflowSearchRsDTOv1 rs = new TwinflowSearchRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/twinflow/TwinflowSchemaSearchController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/twinflow/TwinflowSchemaSearchController.java
@@ -54,7 +54,7 @@ public class TwinflowSchemaSearchController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/twinflow_schema/search/v1")
     public ResponseEntity<?> twinflowSchemaSearchV1(
-            @MapperContextBinding(roots = TwinflowSchemaRestDTOMapperV2.class, response = TwinflowSchemaSearchRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TwinflowSchemaRestDTOMapperV2.class, response = TwinflowSchemaSearchRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @SimplePaginationParams SimplePagination pagination,
             @RequestBody TwinflowSchemaSearchRqDTOv1 request) {
         TwinflowSchemaSearchRsDTOv1 rs = new TwinflowSchemaSearchRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/twinflow/TwinflowUpdateController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/twinflow/TwinflowUpdateController.java
@@ -55,7 +55,7 @@ public class TwinflowUpdateController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PutMapping(value = "/private/twinflow/{twinflowId}/v1")
     public ResponseEntity<?> twinflowUpdateV1(
-            @MapperContextBinding(roots = TwinflowBaseV2RestDTOMapper.class, response = TwinflowRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TwinflowBaseV2RestDTOMapper.class, response = TwinflowRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.TWINFLOW_ID) @PathVariable UUID twinflowId,
             @RequestBody TwinflowUpdateRqDTOv1 request) {
         TwinflowRsDTOv1 rs = new TwinflowRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/twinflow/TwinflowViewController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/twinflow/TwinflowViewController.java
@@ -49,7 +49,7 @@ public class TwinflowViewController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/private/twinflow/{twinflowId}/v1")
     public ResponseEntity<?> twinflowViewV1(
-            @MapperContextBinding(roots = TwinflowBaseV3RestDTOMapper.class, response = TwinflowViewRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TwinflowBaseV3RestDTOMapper.class, response = TwinflowViewRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.TWINFLOW_ID) @PathVariable UUID twinflowId) {
         TwinflowViewRsDTOv1 rs = new TwinflowViewRsDTOv1();
         try {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/twinstatus/TwinStatusCreateController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/twinstatus/TwinStatusCreateController.java
@@ -51,7 +51,7 @@ public class TwinStatusCreateController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/twin_class/{twinClassId}/twin_status/v1")
     public ResponseEntity<?> twinStatusCreateV1(
-            @MapperContextBinding(roots = TwinStatusRestDTOMapper.class, response = TwinStatusCreateRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TwinStatusRestDTOMapper.class, response = TwinStatusCreateRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.TWIN_CLASS_ID) @PathVariable UUID twinClassId,
             @RequestBody TwinStatusCreateRqDTOv1 request) {
         TwinStatusCreateRsDTOv1 rs = new TwinStatusCreateRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/twinstatus/TwinStatusSearchController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/twinstatus/TwinStatusSearchController.java
@@ -54,7 +54,7 @@ public class TwinStatusSearchController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/twin_status/search/v1")
     public ResponseEntity<?> twinStatusSearchV1(
-            @MapperContextBinding(roots = TwinStatusRestDTOMapperV2.class, response = TwinStatusSearchRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TwinStatusRestDTOMapperV2.class, response = TwinStatusSearchRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @SimplePaginationParams SimplePagination pagination,
             @RequestBody TwinStatusSearchRqDTOv1 request) {
         TwinStatusSearchRsDTOv1 rs = new TwinStatusSearchRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/twinstatus/TwinStatusUpdateController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/twinstatus/TwinStatusUpdateController.java
@@ -51,7 +51,7 @@ public class TwinStatusUpdateController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PutMapping(value = "/private/twin_status/{twinStatusId}/v1")
     public ResponseEntity<?> twinStatusUpdateV1(
-            @MapperContextBinding(roots = TwinStatusRestDTOMapper.class, response = TwinStatusUpdateRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TwinStatusRestDTOMapper.class, response = TwinStatusUpdateRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.TWIN_STATUS_ID) @PathVariable UUID twinStatusId,
             @RequestBody TwinStatusUpdateRqDTOv1 request) {
         TwinStatusUpdateRsDTOv1 rs = new TwinStatusUpdateRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/twinstatus/TwinStatusViewController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/twinstatus/TwinStatusViewController.java
@@ -48,7 +48,7 @@ public class TwinStatusViewController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/private/twin_status/{twinStatusId}/v1")
     public ResponseEntity<?> twinStatusViewV1(
-            @MapperContextBinding(roots = TwinStatusRestDTOMapperV2.class, response = TwinStatusRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TwinStatusRestDTOMapperV2.class, response = TwinStatusRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.TWIN_STATUS_ID) @PathVariable UUID twinStatusId) {
         TwinStatusRsDTOv1 rs = new TwinStatusRsDTOv1();
         try {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/twintouch/TwinTouchAddController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/twintouch/TwinTouchAddController.java
@@ -52,7 +52,7 @@ public class TwinTouchAddController extends ApiController {
     public ResponseEntity<?> twinTouchAddV1(
             @Parameter(example = DTOExamples.TWIN_ID) @PathVariable UUID twinId,
             @Parameter(example = DTOExamples.TWIN_TOUCH) @PathVariable String touchId,
-            @MapperContextBinding(roots = TwinTouchRestDTOMapper.class, response = TwinTouchRsDTOv1.class) MapperContext mapperContext) {
+            @MapperContextBinding(roots = TwinTouchRestDTOMapper.class, response = TwinTouchRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext) {
         TwinTouchRsDTOv1 rs = new TwinTouchRsDTOv1();
         try {
             TwinTouchEntity twinTouchEntity = twinTouchService.addTouch(twinId, TwinTouchEntity.Touch.valueOfId(touchId.toUpperCase()));
@@ -75,7 +75,7 @@ public class TwinTouchAddController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/twin/touch/{touchId}/v1")
     public ResponseEntity<?> twinTouchAddListV1 (
-            @MapperContextBinding(roots = TwinTouchRestDTOMapper.class, response = TwinTouchListRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = TwinTouchRestDTOMapper.class, response = TwinTouchListRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.TWIN_TOUCH) @PathVariable String touchId,
             @RequestBody TwinListTouchAddRqDTOv1 request) {
         TwinTouchListRsDTOv1 rs = new TwinTouchListRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/user/UserSearchController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/user/UserSearchController.java
@@ -55,7 +55,7 @@ public class UserSearchController extends ApiController {
     })
     @PostMapping(value = "/private/user/search/v1")
     public ResponseEntity<?> UserSearchV1(
-            @MapperContextBinding(roots = UserRestDTOMapper.class, response = UserSearchRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = UserRestDTOMapper.class, response = UserSearchRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @SimplePaginationParams SimplePagination pagination,
             @RequestBody UserSearchRqDTOv1 request) {
         UserSearchRsDTOv1 rs = new UserSearchRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/usergroup/UserGroupListController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/usergroup/UserGroupListController.java
@@ -49,7 +49,7 @@ public class UserGroupListController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/private/user/{userId}/user_group/v1")
     public ResponseEntity<?> userGroupForUserListV1(
-            @MapperContextBinding(roots = UserGroupRestDTOMapper.class, response = UserGroupListRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = UserGroupRestDTOMapper.class, response = UserGroupListRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.USER_ID) @PathVariable UUID userId) {
         UserGroupListRsDTOv1 rs = new UserGroupListRsDTOv1();
         try {

--- a/core/src/main/java/org/twins/core/controller/rest/priv/usergroup/UserGroupMemberManageController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/usergroup/UserGroupMemberManageController.java
@@ -48,7 +48,7 @@ public class UserGroupMemberManageController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/user/{userId}/user_group/manage/v1")
     public ResponseEntity<?> userGroupMemberManageV1(
-            @MapperContextBinding(roots = UserGroupRestDTOMapper.class, response = UserGroupListRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = UserGroupRestDTOMapper.class, response = UserGroupListRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.USER_ID) @PathVariable UUID userId,
             @RequestBody UserGroupMemberManageRqDTOv1 request) {
         UserGroupListRsDTOv1 rs = new UserGroupListRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/priv/usergroup/UserGroupSearchController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/priv/usergroup/UserGroupSearchController.java
@@ -54,7 +54,7 @@ public class UserGroupSearchController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/private/user_group/search/v1")
     public ResponseEntity<?> userGroupSearchV1(
-            @MapperContextBinding(roots = UserGroupRestDTOMapperV2.class, response = UserGroupSearchRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = UserGroupRestDTOMapperV2.class, response = UserGroupSearchRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @SimplePaginationParams SimplePagination pagination,
             @RequestBody UserGroupSearchRqDTOv1 request) {
         UserGroupSearchRsDTOv1 rs = new UserGroupSearchRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/pub/datalist/DataListOptionPublicController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/pub/datalist/DataListOptionPublicController.java
@@ -16,7 +16,6 @@ import org.twins.core.controller.rest.ApiController;
 import org.twins.core.controller.rest.ApiTag;
 import org.twins.core.controller.rest.annotation.MapperContextBinding;
 import org.twins.core.controller.rest.annotation.ParametersApiUserAnonymousHeaders;
-import org.twins.core.controller.rest.annotation.ProtectedBy;
 import org.twins.core.dao.datalist.DataListOptionEntity;
 import org.twins.core.dto.rest.DTOExamples;
 import org.twins.core.dto.rest.datalist.DataListOptionMapRqDTOv1;
@@ -27,7 +26,6 @@ import org.twins.core.mappers.rest.mappercontext.MapperContext;
 import org.twins.core.service.auth.AuthService;
 import org.twins.core.service.datalist.DataListOptionService;
 import org.twins.core.service.datalist.DataListService;
-import org.twins.core.service.permission.Permissions;
 
 import java.util.UUID;
 
@@ -50,7 +48,7 @@ public class DataListOptionPublicController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @GetMapping(value = "/public/data_list_option/{dataListOptionId}/v1")
     public ResponseEntity<?> dataListOptionPublicViewV1(
-            @MapperContextBinding(roots = DataListOptionRestDTOMapper.class, response = DataListOptionRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = DataListOptionRestDTOMapper.class, response = DataListOptionRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.DATA_LIST_OPTION_ID) @PathVariable UUID dataListOptionId) {
         DataListOptionRsDTOv1 rs = new DataListOptionRsDTOv1();
         try {
@@ -76,7 +74,7 @@ public class DataListOptionPublicController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/public/data_list_option/map/v1")
     public ResponseEntity<?> dataListOptionsMapViewPublicV1(
-            @MapperContextBinding(roots = DataListOptionRestDTOMapper.class, response = DataListOptionMapRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = DataListOptionRestDTOMapper.class, response = DataListOptionMapRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @RequestBody DataListOptionMapRqDTOv1 request) {
         DataListOptionMapRsDTOv1 rs = new DataListOptionMapRsDTOv1();
         try {

--- a/core/src/main/java/org/twins/core/controller/rest/pub/datalist/DataListOptionSearchPublicController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/pub/datalist/DataListOptionSearchPublicController.java
@@ -20,7 +20,6 @@ import org.twins.core.controller.rest.ApiController;
 import org.twins.core.controller.rest.ApiTag;
 import org.twins.core.controller.rest.annotation.MapperContextBinding;
 import org.twins.core.controller.rest.annotation.ParametersApiUserAnonymousHeaders;
-import org.twins.core.controller.rest.annotation.ProtectedBy;
 import org.twins.core.controller.rest.annotation.SimplePaginationParams;
 import org.twins.core.dao.datalist.DataListOptionEntity;
 import org.twins.core.dto.rest.datalist.DataListOptionSearchRqDTOv1;
@@ -32,7 +31,6 @@ import org.twins.core.mappers.rest.pagination.PaginationMapper;
 import org.twins.core.mappers.rest.related.RelatedObjectsRestDTOConverter;
 import org.twins.core.service.auth.AuthService;
 import org.twins.core.service.datalist.DataListOptionSearchService;
-import org.twins.core.service.permission.Permissions;
 
 @Tag(name = ApiTag.DATA_LIST)
 @RestController
@@ -55,7 +53,7 @@ public class DataListOptionSearchPublicController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/public/data_list_option/search/v1")
     public ResponseEntity<?> dataListOptionSearchPublicListV1(
-            @MapperContextBinding(roots = DataListOptionRestDTOMapperV3.class, response = DataListOptionSearchRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = DataListOptionRestDTOMapperV3.class, response = DataListOptionSearchRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @RequestBody DataListOptionSearchRqDTOv1 request,
             @SimplePaginationParams(sortField = DataListOptionEntity.Fields.option) SimplePagination pagination) {
         DataListOptionSearchRsDTOv1 rs = new DataListOptionSearchRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/pub/datalist/DataListPublicController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/pub/datalist/DataListPublicController.java
@@ -16,7 +16,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.twins.core.controller.rest.ApiController;
 import org.twins.core.controller.rest.ApiTag;
-import org.twins.core.controller.rest.annotation.*;
+import org.twins.core.controller.rest.annotation.Loggable;
+import org.twins.core.controller.rest.annotation.MapperContextBinding;
+import org.twins.core.controller.rest.annotation.ParametersApiUserAnonymousHeaders;
+import org.twins.core.controller.rest.annotation.SimplePaginationParams;
 import org.twins.core.dao.datalist.DataListEntity;
 import org.twins.core.dto.rest.DTOExamples;
 import org.twins.core.dto.rest.datalist.DataListRsDTOv1;
@@ -29,7 +32,6 @@ import org.twins.core.mappers.rest.pagination.PaginationMapper;
 import org.twins.core.service.auth.AuthService;
 import org.twins.core.service.datalist.DataListSearchService;
 import org.twins.core.service.datalist.DataListService;
-import org.twins.core.service.permission.Permissions;
 
 import java.util.UUID;
 
@@ -55,7 +57,7 @@ public class DataListPublicController extends ApiController {
     @GetMapping(value = "/public/data_list/{dataListId}/v1")
     @Loggable(rsBodyThreshold = 1000)
     public ResponseEntity<?> dataListPublicViewV1(
-            @MapperContextBinding(roots = DataListRestDTOMapperV2.class, response = DataListRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = DataListRestDTOMapperV2.class, response = DataListRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.DATA_LIST_ID) @PathVariable UUID dataListId) {
         DataListRsDTOv1 rs = new DataListRsDTOv1();
         try {
@@ -80,7 +82,7 @@ public class DataListPublicController extends ApiController {
     @GetMapping(value = "/public/data_list_by_key/{dataListKey}/v1")
     @Loggable(rsBodyThreshold = 1000)
     public ResponseEntity<?> dataListPublicByKeyViewV1(
-            @MapperContextBinding(roots = DataListRestDTOMapperV2.class, response = DataListRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = DataListRestDTOMapperV2.class, response = DataListRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.DATA_LIST_KEY) @PathVariable String dataListKey) {
         DataListRsDTOv1 rs = new DataListRsDTOv1();
         try {
@@ -106,7 +108,7 @@ public class DataListPublicController extends ApiController {
     @PostMapping(value = "/public/data_list/search/v1")
     @Loggable(rsBodyThreshold = 1000)
     public ResponseEntity<?> dataListPublicSearchV1(
-            @MapperContextBinding(roots = DataListRestDTOMapperV2.class, response = DataListSearchRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = DataListRestDTOMapperV2.class, response = DataListSearchRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @SimplePaginationParams SimplePagination pagination,
             @RequestBody DataListSearchRqDTOv1 request) {
         DataListSearchRsDTOv1 rs = new DataListSearchRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/pub/domain/DomainSearchPublicController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/pub/domain/DomainSearchPublicController.java
@@ -48,7 +48,7 @@ public class DomainSearchPublicController extends ApiController {
             @ApiResponse(responseCode = "401", description = "Access is denied")})
     @PostMapping(value = "/public/domain/search/v1")
     public ResponseEntity<?> domainSearchPublicV1(
-            @MapperContextBinding(roots = DomainViewPublicRestDTOMapper.class, response = DomainPublicSearchRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = DomainViewPublicRestDTOMapper.class, response = DomainPublicSearchRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @SimplePaginationParams SimplePagination pagination,
             @RequestBody DomainPublicSearchRqDTOv1 request) {
         DomainPublicSearchRsDTOv1 rs = new DomainPublicSearchRsDTOv1();

--- a/core/src/main/java/org/twins/core/controller/rest/pub/domain/DomainViewPublicController.java
+++ b/core/src/main/java/org/twins/core/controller/rest/pub/domain/DomainViewPublicController.java
@@ -19,14 +19,12 @@ import org.twins.core.controller.rest.ApiController;
 import org.twins.core.controller.rest.ApiTag;
 import org.twins.core.controller.rest.annotation.Loggable;
 import org.twins.core.controller.rest.annotation.MapperContextBinding;
-import org.twins.core.controller.rest.annotation.ProtectedBy;
 import org.twins.core.dto.rest.DTOExamples;
 import org.twins.core.dto.rest.domain.DomainViewPublicRsDTOv1;
 import org.twins.core.mappers.rest.domain.DomainViewPublicRestDTOMapper;
 import org.twins.core.mappers.rest.mappercontext.MapperContext;
 import org.twins.core.service.auth.AuthService;
 import org.twins.core.service.domain.DomainService;
-import org.twins.core.service.permission.Permissions;
 
 import java.util.UUID;
 
@@ -48,7 +46,7 @@ public class DomainViewPublicController extends ApiController {
     @GetMapping(value = "/public/domain/{domainId}/v1")
     @Loggable(rsBodyThreshold = 1000)
     public ResponseEntity<?> domainViewPublicV1(
-            @MapperContextBinding(roots = DomainViewPublicRestDTOMapper.class, response = DomainViewPublicRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = DomainViewPublicRestDTOMapper.class, response = DomainViewPublicRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.DOMAIN_ID) @PathVariable UUID domainId) {
         DomainViewPublicRsDTOv1 rs = new DomainViewPublicRsDTOv1();
         try {
@@ -72,7 +70,7 @@ public class DomainViewPublicController extends ApiController {
     @GetMapping(value = "/public/domain_by_key/{domainKey}/v1")
     @Loggable(rsBodyThreshold = 1000)
     public ResponseEntity<?> domainViewByKeyPublicV1(
-            @MapperContextBinding(roots = DomainViewPublicRestDTOMapper.class, response = DomainViewPublicRsDTOv1.class) MapperContext mapperContext,
+            @MapperContextBinding(roots = DomainViewPublicRestDTOMapper.class, response = DomainViewPublicRsDTOv1.class) @Schema(hidden = true) MapperContext mapperContext,
             @Parameter(example = DTOExamples.DOMAIN_KEY) @PathVariable String domainKey) {
         DomainViewPublicRsDTOv1 rs = new DomainViewPublicRsDTOv1();
         try {


### PR DESCRIPTION
Add `@Schema(hidden = true)` to `@MapperContextBinding` annotations across controllers

Enhanced API documentation consistency by marking `MapperContext` parameters as hidden in the schema definition.