### PR TITLE
 Add batch i18n and improve createDataListOptions performance

### DIFF
--- a/core/src/main/java/org/twins/core/dao/i18n/I18nEntity.java
+++ b/core/src/main/java/org/twins/core/dao/i18n/I18nEntity.java
@@ -71,6 +71,9 @@ public class I18nEntity {
     }
 
     @Transient
+    private Object externalId;
+
+    @Transient
     private Kit<I18nTranslationBinEntity, Locale> translationsBin;
 
     @Override

--- a/core/src/main/java/org/twins/core/service/i18n/I18nService.java
+++ b/core/src/main/java/org/twins/core/service/i18n/I18nService.java
@@ -29,6 +29,8 @@ import org.twins.core.service.domain.DomainService;
 
 import java.util.*;
 import java.util.function.Function;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 
 @Component
@@ -263,9 +265,9 @@ public class I18nService extends EntitySecureFindServiceImpl<I18nEntity> {
 
     @Transactional(rollbackFor = Throwable.class)
     public I18nEntity createI18nAndTranslations(I18nType i18nType, I18nEntity i18nEntity) throws ServiceException {
-        if(null == i18nType)
+        if (null == i18nType)
             throw new ServiceException(ErrorCodeI18n.INCORRECT_CONFIGURATION, "i18n type not specified");
-        if(null == i18nEntity)
+        if (null == i18nEntity)
             i18nEntity = new I18nEntity();
 //        if (!i18nType.equals(i18nEntity.getType()))
 //            throw new ServiceException(ErrorCodeI18n.INCORRECT_CONFIGURATION, "i18n type mismatch");
@@ -283,6 +285,30 @@ public class I18nService extends EntitySecureFindServiceImpl<I18nEntity> {
         }
         i18nTranslationRepository.saveAll(i18nEntity.getTranslationsKit().getCollection());
         return i18nEntity;
+    }
+
+    public List<I18nEntity> createI18nAndTranslations(I18nType i18nType, List<I18nEntity> i18nEntities) throws ServiceException {
+        if (null == i18nType)
+            throw new ServiceException(ErrorCodeI18n.INCORRECT_CONFIGURATION, "i18n type not specified");
+        i18nEntities.forEach(i -> {
+            i.setType(i18nType);
+            i.setId(null);
+        });
+        var saved = StreamSupport.stream(i18nRepository.saveAll(i18nEntities).spliterator(), false).toList();
+        var translations = saved.stream().flatMap(i18nEntity -> {
+            var kit = i18nEntity.getTranslationsKit();
+            if (kit != null) {
+                return kit.getList().stream().peek(t -> {
+                    t.setI18nId(i18nEntity.getId());
+                    t.setI18n(i18nEntity);
+                    t.setTranslation(StringUtils.defaultString(t.getTranslation()));
+                });
+            } else {
+                return Stream.empty();
+            }
+        }).toList();
+        i18nTranslationRepository.saveAll(translations);
+        return i18nEntities;
     }
 
     private String addCopyPostfix(String originalStr) {
@@ -307,7 +333,7 @@ public class I18nService extends EntitySecureFindServiceImpl<I18nEntity> {
         try {
             apiUser = authService.getApiUser();
             Locale domainLocale = null;
-            if(apiUser.isDomainSpecified())
+            if (apiUser.isDomainSpecified())
                 domainLocale = apiUser.getDomain().getDefaultI18nLocaleId();
             return domainLocale != null ? domainLocale : i18nProperties.defaultLocale();
         } catch (ServiceException e) {


### PR DESCRIPTION
* Introduced a batch method `createI18nAndTranslations` for handling multiple I18n entities at once.
* Optimized `createDataListOptions` by batching i18n translations and improving logging with detailed execution times.