### PR TITLE
Twins 447

### DIFF
--- a/core/src/main/java/org/twins/core/dao/i18n/I18nEntity.java
+++ b/core/src/main/java/org/twins/core/dao/i18n/I18nEntity.java
@@ -70,7 +70,6 @@ public class I18nEntity {
         return this;
     }
 
-
     @Transient
     private Kit<I18nTranslationBinEntity, Locale> translationsBin;
 

--- a/core/src/main/java/org/twins/core/dao/i18n/I18nEntity.java
+++ b/core/src/main/java/org/twins/core/dao/i18n/I18nEntity.java
@@ -70,8 +70,6 @@ public class I18nEntity {
         return this;
     }
 
-    @Transient
-    private Object externalId;
 
     @Transient
     private Kit<I18nTranslationBinEntity, Locale> translationsBin;

--- a/core/src/main/java/org/twins/core/dao/i18n/I18nEntity.java
+++ b/core/src/main/java/org/twins/core/dao/i18n/I18nEntity.java
@@ -71,6 +71,9 @@ public class I18nEntity {
     }
 
     @Transient
+    private Object externalId;
+
+    @Transient
     private Kit<I18nTranslationBinEntity, Locale> translationsBin;
 
     @Override

--- a/core/src/main/java/org/twins/core/service/datalist/DataListOptionService.java
+++ b/core/src/main/java/org/twins/core/service/datalist/DataListOptionService.java
@@ -31,7 +31,6 @@ import org.twins.core.service.auth.AuthService;
 import org.twins.core.service.i18n.I18nService;
 
 import java.util.*;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -96,21 +95,17 @@ public class DataListOptionService extends EntitySecureFindServiceImpl<DataListO
         log.debug("createDataListOptions find all data lists in {} ms", System.currentTimeMillis() - time);
         time = System.currentTimeMillis();
         //And it's translations
-        List<I18nEntity> translations = i18nService.createI18nAndTranslations(I18nType.DATA_LIST_OPTION_VALUE,
+        i18nService.createI18nAndTranslations(I18nType.DATA_LIST_OPTION_VALUE,
                 dataListOptionCreates
                         .stream().map(DataListOptionCreate::getNameI18n)
                         .toList());
         log.debug("createDataListOptions create i18n in {} ms", System.currentTimeMillis() - time);
         time = System.currentTimeMillis();
-        AtomicInteger atomicIndex = new AtomicInteger(0);
         for (DataListOptionCreate dataListOptionCreate : dataListOptionCreates) {
-            //Translations should have the same order as dataListOptionCreates, so map an option to it's translation
-            int index = atomicIndex.getAndIncrement();
-            var translation = translations.get(index);
             DataListEntity dataList = dataListsMap.get(dataListOptionCreate.getDataListId());
             loadDataListAttributeAccessors(dataList);
             DataListOptionEntity dataListOption = new DataListOptionEntity()
-                    .setOptionI18NId(translation.getId())
+                    .setOptionI18NId(dataListOptionCreate.getNameI18n().getId())
                     .setDataListId(dataListOptionCreate.getDataListId())
                     .setIcon(dataListOptionCreate.getIcon())
                     .setStatus(DataListOptionEntity.Status.active)

--- a/core/src/main/java/org/twins/core/service/datalist/DataListOptionService.java
+++ b/core/src/main/java/org/twins/core/service/datalist/DataListOptionService.java
@@ -90,17 +90,12 @@ public class DataListOptionService extends EntitySecureFindServiceImpl<DataListO
         }
         List<DataListOptionEntity> optionsToSave = new ArrayList<>();
         //Find all entities
-        Long time = System.currentTimeMillis();
         Map<UUID, DataListEntity> dataListsMap = dataListService.findEntitiesSafe(dataListOptionCreates.stream().map(DataListOptionCreate::getDataListId).collect(Collectors.toList())).getList().stream().collect(Collectors.toMap(DataListEntity::getId, a -> a));
-        log.debug("createDataListOptions find all data lists in {} ms", System.currentTimeMillis() - time);
-        time = System.currentTimeMillis();
         //And it's translations
         i18nService.createI18nAndTranslations(I18nType.DATA_LIST_OPTION_VALUE,
                 dataListOptionCreates
                         .stream().map(DataListOptionCreate::getNameI18n)
                         .toList());
-        log.debug("createDataListOptions create i18n in {} ms", System.currentTimeMillis() - time);
-        time = System.currentTimeMillis();
         for (DataListOptionCreate dataListOptionCreate : dataListOptionCreates) {
             DataListEntity dataList = dataListsMap.get(dataListOptionCreate.getDataListId());
             loadDataListAttributeAccessors(dataList);
@@ -116,10 +111,7 @@ public class DataListOptionService extends EntitySecureFindServiceImpl<DataListO
             validateEntityAndThrow(dataListOption, EntitySmartService.EntityValidateMode.beforeSave);
             optionsToSave.add(dataListOption);
         }
-        log.debug("createDataListOptions create data list options in {} ms", System.currentTimeMillis() - time);
-        time = System.currentTimeMillis();
         List<DataListOptionEntity> result = StreamSupport.stream(entityRepository().saveAll(optionsToSave).spliterator(), false).toList();
-        log.debug("createDataListOptions save data list options in {} ms", System.currentTimeMillis() - time);
         return result;
     }
 

--- a/core/src/main/java/org/twins/core/service/i18n/I18nService.java
+++ b/core/src/main/java/org/twins/core/service/i18n/I18nService.java
@@ -29,6 +29,8 @@ import org.twins.core.service.domain.DomainService;
 
 import java.util.*;
 import java.util.function.Function;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 
 @Component
@@ -263,9 +265,9 @@ public class I18nService extends EntitySecureFindServiceImpl<I18nEntity> {
 
     @Transactional(rollbackFor = Throwable.class)
     public I18nEntity createI18nAndTranslations(I18nType i18nType, I18nEntity i18nEntity) throws ServiceException {
-        if(null == i18nType)
+        if (null == i18nType)
             throw new ServiceException(ErrorCodeI18n.INCORRECT_CONFIGURATION, "i18n type not specified");
-        if(null == i18nEntity)
+        if (null == i18nEntity)
             i18nEntity = new I18nEntity();
 //        if (!i18nType.equals(i18nEntity.getType()))
 //            throw new ServiceException(ErrorCodeI18n.INCORRECT_CONFIGURATION, "i18n type mismatch");
@@ -283,6 +285,30 @@ public class I18nService extends EntitySecureFindServiceImpl<I18nEntity> {
         }
         i18nTranslationRepository.saveAll(i18nEntity.getTranslationsKit().getCollection());
         return i18nEntity;
+    }
+
+    public List<I18nEntity> createI18nAndTranslations(I18nType i18nType, List<I18nEntity> i18nEntities) throws ServiceException {
+        if (null == i18nType)
+            throw new ServiceException(ErrorCodeI18n.INCORRECT_CONFIGURATION, "i18n type not specified");
+        i18nEntities.forEach(i -> {
+            i.setType(i18nType);
+            i.setId(null);
+        });
+        var saved = StreamSupport.stream(i18nRepository.saveAll(i18nEntities).spliterator(), false).toList();
+        var translations = saved.stream().flatMap(i18nEntity -> {
+            var kit = i18nEntity.getTranslationsKit();
+            if (kit != null) {
+                return kit.getList().stream().peek(t -> {
+                    t.setI18nId(i18nEntity.getId());
+                    t.setI18n(i18nEntity);
+                    t.setTranslation(StringUtils.defaultString(t.getTranslation()));
+                });
+            } else {
+                return Stream.empty();
+            }
+        }).toList();
+        i18nTranslationRepository.saveAll(translations);
+        return i18nEntities;
     }
 
     private String addCopyPostfix(String originalStr) {
@@ -307,7 +333,7 @@ public class I18nService extends EntitySecureFindServiceImpl<I18nEntity> {
         try {
             apiUser = authService.getApiUser();
             Locale domainLocale = null;
-            if(apiUser.isDomainSpecified())
+            if (apiUser.isDomainSpecified())
                 domainLocale = apiUser.getDomain().getDefaultI18nLocaleId();
             return domainLocale != null ? domainLocale : i18nProperties.defaultLocale();
         } catch (ServiceException e) {


### PR DESCRIPTION
* Introduced a batch method `createI18nAndTranslations` for handling multiple I18n entities at once.
* Optimized `createDataListOptions` by batching i18n translations and improving logging with detailed execution times.